### PR TITLE
Enable mirror lockup wait in seconds

### DIFF
--- a/indigo_linux_drivers/ccd_gphoto2/README.md
+++ b/indigo_linux_drivers/ccd_gphoto2/README.md
@@ -49,6 +49,8 @@ if an exposure value of 24 seconds is chosen, then the predefined value of 25 se
 indigo_ccd_gphoto2 driver. In bulb setting, any non-negative exposure value can be chosen,
 for instance exactly 24 seconds or 180 seconds. If highly precise exposure values
 below 1 seconds are required it is advised to operate in the shutterspeed setting, otherwise in bulb setting.
+If exposure time in INDIGO is set 0 seconds and camera is in non-bulb, then shutterspeed value 1/4000 is set.
+This is consistent with the statements above.
 
 ### Mirror lockup
 Fast-flipping mirror can cause vibrations of the camera and the mount.


### PR DESCRIPTION
If mirror lockup time is 0 seconds, then mirror lockup
is disabled. Otherwise the mirror is flipped and the drivers
waits for mirror lockup time before the exposure starts.