### PR TITLE
Fix NULL assignment warning

### DIFF
--- a/indigo_drivers/agent_lx200_server/indigo_agent_lx200_server.c
+++ b/indigo_drivers/agent_lx200_server/indigo_agent_lx200_server.c
@@ -364,7 +364,7 @@ static void shutdown_server(indigo_device *device) {
 		shutdown(server_socket, SHUT_RDWR);
 		close(server_socket);
 		pthread_join(DEVICE_PRIVATE_DATA->listener, NULL);
-		DEVICE_PRIVATE_DATA->listener = NULL;
+		DEVICE_PRIVATE_DATA->listener = 0;
 		LX200_SERVER_PROPERTY->state = INDIGO_OK_STATE;
 	}
 	indigo_update_property(device, LX200_SERVER_PROPERTY, NULL);


### PR DESCRIPTION
pthread_t is defined in
/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h:
as
typedef unsigned long int pthread_t;
thus assign 0 rather than NULL.