### PR TITLE
Add missing header file for malloc

### DIFF
--- a/indigo_linux_drivers/ccd_gphoto2/indigo_ccd_gphoto2_main.c
+++ b/indigo_linux_drivers/ccd_gphoto2/indigo_ccd_gphoto2_main.c
@@ -25,9 +25,9 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include "indigo_driver_xml.h"
-
 #include "indigo_ccd_gphoto2.h"
 
 int main(int argc, const char * argv[]) {


### PR DESCRIPTION
Fix the issue:
warning: incompatible implicit declaration of built-in function ‘malloc’
note: include ‘<stdlib.h>’ or provide a declaration of ‘malloc’