### PR TITLE
Fix installing binaries in /usr/local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,6 @@ reconfigure:
 	install -d -m 0755 $(INSTALL_RULES)
 	install -d -m 0755 $(INSTALL_FIRMWARE)
 
-install: INSTALL_ROOT = $(INDIGO_ROOT)/install
 install: reconfigure init all
 	@$(MAKE)	-C indigo_libs install
 	@$(MAKE)	-C indigo_drivers -f ../Makefile.drvs install
@@ -154,7 +153,6 @@ endif
 	@$(MAKE)	-C indigo_server install
 	@$(MAKE)	-C indigo_tools install
 
-uninstall: INSTALL_ROOT = $(INDIGO_ROOT)/install
 uninstall: reconfigure init
 	@$(MAKE)	-C indigo_libs uninstall
 	@$(MAKE)	-C indigo_drivers -f ../Makefile.drvs uninstall


### PR DESCRIPTION
The command "sudo make install" should
install in directory /usr/local rather
than "$(INDIGO_ROOT)/install". This patch
fix that for install and uninstall.