### PR TITLE
Make Gphoto2 driver name consistent with other CCD drivers

### DIFF
--- a/indigo_linux_drivers/ccd_gphoto2/indigo_ccd_gphoto2.c
+++ b/indigo_linux_drivers/ccd_gphoto2/indigo_ccd_gphoto2.c
@@ -2129,7 +2129,7 @@ indigo_result indigo_ccd_gphoto2(indigo_driver_action action, indigo_driver_info
 
 	static indigo_driver_action last_action = INDIGO_DRIVER_SHUTDOWN;
 
-	SET_DRIVER_INFO(info, "gphoto2 camera", __FUNCTION__, DRIVER_VERSION, true, last_action);
+	SET_DRIVER_INFO(info, "Gghoto2 Camera", __FUNCTION__, DRIVER_VERSION, true, last_action);
 
 	if (action == last_action)
 		return INDIGO_OK;


### PR DESCRIPTION
INDIGO CCD drivers have consistent naming, e.g.

* QSI Camera
* Moravian Instruments Camera
* SBIG Camera
* Starlight Xpress Camera
* ToupTek Camera
* ...

This patch makes sure to follow this naming convention.