### PR TITLE
Generalize test suite beyond simulators and fix gphoto2 typo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-5
-            - build-essential autoconf autotools-dev libtool cmake libudev-dev libavahi-compat-libdnssd-dev libusb-1.0-0-dev fxload libcurl4-gnutls-dev libgphoto2-dev git curl dpkg fakeroot fxload libusb-1.0-0 libgudev-1.0-0 libgphoto2-6 libavahi-compat-libdnssd1
+            - build-essential autoconf autotools-dev libtool cmake libudev-dev libavahi-compat-libdnssd-dev libusb-1.0-0-dev fxload libcurl4-gnutls-dev libgphoto2-dev git curl dpkg fakeroot fxload libusb-1.0-0 libgudev-1.0-0 libgphoto2-6 libavahi-compat-libdnssd1 psmisc
       env:
          - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
 
@@ -30,7 +30,7 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-6
-            - build-essential autoconf autotools-dev libtool cmake libudev-dev libavahi-compat-libdnssd-dev libusb-1.0-0-dev fxload libcurl4-gnutls-dev libgphoto2-dev git curl dpkg fakeroot fxload libusb-1.0-0 libgudev-1.0-0 libgphoto2-6 libavahi-compat-libdnssd1
+            - build-essential autoconf autotools-dev libtool cmake libudev-dev libavahi-compat-libdnssd-dev libusb-1.0-0-dev fxload libcurl4-gnutls-dev libgphoto2-dev git curl dpkg fakeroot fxload libusb-1.0-0 libgudev-1.0-0 libgphoto2-6 libavahi-compat-libdnssd1 psmisc
       env:
         - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
 
@@ -42,7 +42,7 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-7
-            - build-essential autoconf autotools-dev libtool cmake libudev-dev libavahi-compat-libdnssd-dev libusb-1.0-0-dev fxload libcurl4-gnutls-dev libgphoto2-dev git curl dpkg fakeroot fxload libusb-1.0-0 libgudev-1.0-0 libgphoto2-6 libavahi-compat-libdnssd1
+            - build-essential autoconf autotools-dev libtool cmake libudev-dev libavahi-compat-libdnssd-dev libusb-1.0-0-dev fxload libcurl4-gnutls-dev libgphoto2-dev git curl dpkg fakeroot fxload libusb-1.0-0 libgudev-1.0-0 libgphoto2-6 libavahi-compat-libdnssd1 psmisc
       env:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
 
@@ -53,4 +53,4 @@ before_install:
 script:
   - make
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make package && sudo dpkg --install indigo*.deb && sudo ldconfig ; fi
-  - indigo_test/test_suite.sh --driver-test --format-test indigo_ccd_simulator
+  - indigo_test/test_suite.sh --driver-test --format-test indigo_ccd_simulator --capture-test indigo_ccd_simulator

--- a/indigo_linux_drivers/ccd_gphoto2/indigo_ccd_gphoto2.c
+++ b/indigo_linux_drivers/ccd_gphoto2/indigo_ccd_gphoto2.c
@@ -23,7 +23,7 @@
  \file indigo_ccd_gphoto2.c
  */
 
-#define DRIVER_VERSION 0x0002
+#define DRIVER_VERSION 0x0003
 #define DRIVER_NAME "indigo_ccd_gphoto2"
 
 #include <stdio.h>
@@ -841,8 +841,7 @@ static void exposure_timer_callback(indigo_device *device)
 			}
 		}
 		CCD_EXPOSURE_PROPERTY->state = INDIGO_OK_STATE;
-		/* Set exposure value to previous value when not otherwise intended. */
-		CCD_EXPOSURE_ITEM->number.value = CCD_EXPOSURE_ITEM->number.target;
+		CCD_EXPOSURE_ITEM->number.value = 0;
 		indigo_update_property(device, CCD_EXPOSURE_PROPERTY, NULL);
 	} else {
 		CCD_EXPOSURE_PROPERTY->state = INDIGO_ALERT_STATE;
@@ -2130,7 +2129,7 @@ indigo_result indigo_ccd_gphoto2(indigo_driver_action action, indigo_driver_info
 
 	static indigo_driver_action last_action = INDIGO_DRIVER_SHUTDOWN;
 
-	SET_DRIVER_INFO(info, "Gghoto2 Camera", __FUNCTION__, DRIVER_VERSION, true, last_action);
+	SET_DRIVER_INFO(info, "Gphoto2 Camera", __FUNCTION__, DRIVER_VERSION, true, last_action);
 
 	if (action == last_action)
 		return INDIGO_OK;


### PR DESCRIPTION
In addition, set CCD_EXPOSURE_ITEM->number.value = 0 after
a successful exposure to be conform with the other CCD drivers.