### PR TITLE
Verify via assert that DSLR_SHUTTER_PROPERTY is available

### DIFF
--- a/indigo_linux_drivers/ccd_gphoto2/indigo_ccd_gphoto2.c
+++ b/indigo_linux_drivers/ccd_gphoto2/indigo_ccd_gphoto2.c
@@ -1510,6 +1510,13 @@ static indigo_result ccd_attach(indigo_device *device)
 				      "%s",
 				      PRIVATE_DATA->libgphoto2_version);
 
+		/*----------------------- SANITY CHECK -----------------------*/
+		if (!DSLR_SHUTTER_PROPERTY) {
+			INDIGO_DRIVER_ERROR(DRIVER_NAME, "%s (%s) cannot be initializated",
+					    "DSLR_SHUTTER_PROPERTY", GPHOTO2_NAME_SHUTTER);
+			assert(DSLR_SHUTTER_PROPERTY != NULL);
+		}
+
 		/*--------------------- CCD_EXPOSURE_ITEM --------------------*/
 		double number_min = 3600;
 		double number_max = -number_min;


### PR DESCRIPTION
For tested EOS/Nikon cameras, the property
shutterspeed is named in libgphoto2 "shutterspeed". However, there
exists e.g. cell phones such as 'Huawei P9 Plus 12d1:107e' which are
detected by libgphoto2, however, does not possess the shutterspeed property,
e.g. due having a different name. This patch makes sure, the driver
will quit with proper assert message when required property does not exist.