### PR TITLE
Fix crash when possbile shutter speeds are not enumerated by libgphoto2

### DIFF
--- a/indigo_linux_drivers/ccd_gphoto2/indigo_ccd_gphoto2.c
+++ b/indigo_linux_drivers/ccd_gphoto2/indigo_ccd_gphoto2.c
@@ -1250,7 +1250,7 @@ static void shutterspeed_closest(indigo_device *device)
 {
 	assert(device != NULL);
 
-	if (!CCD_EXPOSURE_ITEM || !DSLR_SHUTTER_PROPERTY)
+	if (!CCD_EXPOSURE_ITEM || !DSLR_SHUTTER_PROPERTY || DSLR_SHUTTER_PROPERTY->count == 0)
 		return;
 
 	const double val = CCD_EXPOSURE_ITEM->number.value;


### PR DESCRIPTION
libgphoto2 does not enumerate the shutter speeds for Sony A7 cameras, causing the indigo_ccd_gphoto2 driver to crash. This doesn't make the camera work, but it does fix the crash.