### PR TITLE
Don't mess up abort flag if no park or slew is happening

### DIFF
--- a/indigo_drivers/mount_synscan/indigo_mount_synscan.c
+++ b/indigo_drivers/mount_synscan/indigo_mount_synscan.c
@@ -338,29 +338,6 @@ static indigo_result guider_change_property(indigo_device *device, indigo_client
 	if (indigo_property_match(CONNECTION_PROPERTY, property)) {
 		indigo_property_copy_values(CONNECTION_PROPERTY, property, false);
 		synscan_mount_connect(device);
-//		if (CONNECTION_CONNECTED_ITEM->sw.value) {
-//			if (!device->is_connected) {
-//				if (mount_open(device)) {
-//					device->is_connected = true;
-//					indigo_define_property(device, COMMAND_GUIDE_RATE_PROPERTY, NULL);
-//					PRIVATE_DATA->guider_timer_ra = NULL;
-//					PRIVATE_DATA->guider_timer_dec = NULL;
-//					CONNECTION_PROPERTY->state = INDIGO_OK_STATE;
-//					GUIDER_GUIDE_DEC_PROPERTY->hidden = false;
-//					GUIDER_GUIDE_RA_PROPERTY->hidden = false;
-//				} else {
-//					CONNECTION_PROPERTY->state = INDIGO_ALERT_STATE;
-//					indigo_set_switch(CONNECTION_PROPERTY, CONNECTION_DISCONNECTED_ITEM, true);
-//				}
-//			}
-//		} else {
-//			if (device->is_connected) {
-//				mount_close(device);
-//				indigo_delete_property(device, COMMAND_GUIDE_RATE_PROPERTY, NULL);
-//				device->is_connected = false;
-//				CONNECTION_PROPERTY->state = INDIGO_OK_STATE;
-//			}
-//		}
 	}
 	else if (indigo_property_match(GUIDER_GUIDE_RA_PROPERTY, property)) {
 		// -------------------------------------------------------------------------------- GUIDER_GUIDE_RA

--- a/indigo_drivers/mount_synscan/indigo_mount_synscan_mount.c
+++ b/indigo_drivers/mount_synscan/indigo_mount_synscan_mount.c
@@ -144,10 +144,10 @@ static void position_timer_callback(indigo_device *device) {
 			double aligned_ha = lst - MOUNT_EQUATORIAL_COORDINATES_RA_ITEM->number.value;
 			double aligned_dec = MOUNT_EQUATORIAL_COORDINATES_DEC_ITEM->number.value * M_PI / 180.0;
 
-			if (aligned_ha < 0.0)
-				aligned_ha += 24.0;
-			if (aligned_ha >= 24.0)
-				aligned_ha -= 24.0;
+//			if (aligned_ha < 0.0)
+//				aligned_ha += 24.0;
+//			if (aligned_ha >= 24.0)
+//				aligned_ha -= 24.0;
 			aligned_ha = aligned_ha * M_PI / 12.0;
 
 			sla_de2h(aligned_ha, aligned_dec, lat, &az, &alt);
@@ -832,8 +832,10 @@ void mount_handle_st4_guiding_rate(indigo_device *device) {
 
 void mount_handle_abort(indigo_device *device) {
 	if (MOUNT_ABORT_MOTION_ITEM->sw.value) {
-		//  Cancel any park or slew in progress
-		PRIVATE_DATA->abort_motion = true;
+		if (PRIVATE_DATA->globalMode != kGlobalModeIdle) {
+			//  Cancel any park or slew in progress
+			PRIVATE_DATA->abort_motion = true;
+		}
 
 		//  Unconditionally stop motors in case mount is out of control for any reason
 		synscan_stop_axis(device, kAxisRA);


### PR DESCRIPTION
Correct issue with coordinates update (current position) during certain periods of LST