### PR TITLE
Add check for armv6l architecture in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,10 @@ else
 		INSTALL_ROOT = $(INDIGO_ROOT)/install
 	endif
 	ifeq ($(OS_DETECTED),Linux)
+		ifeq ($(ARCH_DETECTED),armv6l)
+			ARCH_DETECTED = arm
+			DEBIAN_ARCH = armhf
+		endif
 		ifeq ($(ARCH_DETECTED),armv7l)
 			ARCH_DETECTED = arm
 			DEBIAN_ARCH = armhf


### PR DESCRIPTION
The Makefile did not have an option for armv6l architecture. This made
the build fail on some devices (e.g. Raspberry Pi 0 and 1) as the CFLAGS
and CXXFLAGS were not being set properly. This commit adds a check for armv6l.