### PR TITLE
Revert "Wrong typedef for signed size on windows"

### DIFF
--- a/indigo_libs/indigo_client_xml.c
+++ b/indigo_libs/indigo_client_xml.c
@@ -38,8 +38,7 @@
 #if defined(INDIGO_WINDOWS)
 #include <io.h>
 #include <winsock2.h>
-#include <basetsd.h>
-#define ssize_t SSIZE_T
+#define ssize_t size_t
 #define close closesocket
 #pragma warning(disable:4996)
 #endif

--- a/indigo_libs/indigo_xml.c
+++ b/indigo_libs/indigo_xml.c
@@ -40,8 +40,7 @@
 #endif
 #if defined(INDIGO_WINDOWS)
 #include <io.h>
-#include <basetsd.h>
-#define ssize_t SSIZE_T
+#define ssize_t size_t
 #define close indigo_close
 #pragma warning(disable:4996)
 #endif

--- a/indigo_windows/indigo_client/indigo_client.vcxproj
+++ b/indigo_windows/indigo_client/indigo_client.vcxproj
@@ -23,7 +23,7 @@
     <ProjectGuid>{5502C713-37D8-4FC1-95C6-D8A1BA1F1694}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>indigoclient</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -40,7 +40,7 @@
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
@@ -101,13 +101,12 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;INDIGOCLIENT_EXPORTS;_WINDOWS;_USRDLL;INDIGO_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;INDIGOCLIENT_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>C:\Users\Klaus\source\repos\kkretzschmar\indigo\indigo_windows\indigo_client\externals\pthreads4w\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
Reverts indigo-astronomy/indigo#198

please fix absolute path:
   <AdditionalIncludeDirectories>C:\Users\Klaus\source\repos\kkretzschmar\indigo\indigo_windows\indigo_client\externals\pthreads4w\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>