### PR TITLE
Disable/stop hostapd daemon in Wifi infrastructure mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,8 @@ endif
 	printf "rm -f /usr/local/lib/libaltaircam.$(SOEXT)\n" >> $(INSTALL_ROOT)/DEBIAN/preinst
 	printf "rm -rf /usr/local/etc/apogee\n" >> $(INSTALL_ROOT)/DEBIAN/preinst
 	chmod a+x $(INSTALL_ROOT)/DEBIAN/preinst
+	cat tools/rpi_ctrl_fix.sh > $(INSTALL_ROOT)/DEBIAN/postinst
+	chmod a+x $(INSTALL_ROOT)/DEBIAN/postinst
 	rm -f $(INSTALL_ROOT).deb
 	fakeroot dpkg --build $(INSTALL_ROOT)
 #	rm -rf $(INSTALL_ROOT)

--- a/tools/rpi_ctrl_fix.sh
+++ b/tools/rpi_ctrl_fix.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+RPI_CTRL="/usr/bin/rpi_ctrl.sh"
+DHCPCD_CONF="/etc/dhcpcd.conf"
+
+[ ! -f ${RPI_CTRL} ] && { echo "no patch applied because no INDIGO Sky installation"; exit 0; }
+[ ! -f ${DHCPCD_CONF} ] && { echo "cannot apply patch because ${DHCPCD_CONF} is missing"; exit 0; }
+
+if ! grep -Eq "^interface wlan0|^static ip_address=192.168.235.1/24|^nohook wpa_supplicant" /etc/dhcpcd.conf; then
+
+    if ! systemctl is-active --quiet hostapd; then
+	echo "INDIGO Sky is in WiFi infrastructure mode and hostapd daemon is not active"
+	exit 0
+    fi
+    
+    echo "INDIGO Sky is in WiFi infrastructure mode, try to stop and disable hostapd daemon"
+    # Stop hostapd daemon.
+    systemctl stop hostapd
+    if [ $? -eq 0 ]; then
+	echo "Daemon hostapd stopped"
+    else
+	echo "Cannot stop hostapd"
+    fi
+    # Disable hostapd daemon.
+    systemctl disable hostapd
+    if [ $? -eq 0 ]; then
+	echo "Daemon hostapd disabled"
+    else
+	echo "Cannot disable hostapd"
+    fi
+else
+    echo "INDIGO Sky is in WiFi access point mode, no software maintainance is required"
+fi
+

--- a/tools/rpi_ctrl_fix.sh
+++ b/tools/rpi_ctrl_fix.sh
@@ -3,6 +3,7 @@
 RPI_CTRL="/usr/bin/rpi_ctrl.sh"
 DHCPCD_CONF="/etc/dhcpcd.conf"
 
+[ ! `hostname` = "indigosky" ] && { echo "no patch applied because no INDIGO Sky installation"; exit 0; }
 [ ! -f ${RPI_CTRL} ] && { echo "no patch applied because no INDIGO Sky installation"; exit 0; }
 [ ! -f ${DHCPCD_CONF} ] && { echo "cannot apply patch because ${DHCPCD_CONF} is missing"; exit 0; }
 
@@ -31,4 +32,3 @@ if ! grep -Eq "^interface wlan0|^static ip_address=192.168.235.1/24|^nohook wpa_
 else
     echo "INDIGO Sky is in WiFi access point mode, no software maintainance is required"
 fi
-


### PR DESCRIPTION
If INDIGO Sky is in Wifi infrastructure mode and
hostapd daemon is running, then this causes a malfunctioning
of mDNS after some time.