### PR TITLE
Divide current by 65.0 and not 600.0

### DIFF
--- a/indigo_drivers/aux_ppb/indigo_aux_ppb.c
+++ b/indigo_drivers/aux_ppb/indigo_aux_ppb.c
@@ -23,7 +23,7 @@
  \file indigo_aux_ppb.c
  */
 
-#define DRIVER_VERSION 0x000C
+#define DRIVER_VERSION 0x000D
 #define DRIVER_NAME "indigo_aux_ppb"
 
 #include <stdlib.h>
@@ -222,7 +222,7 @@ static void aux_timer_callback(indigo_device *device) {
 			}
 		}
 		if ((token = strtok_r(NULL, ":", &pnt))) { // Current
-			double value = atof(token) / 600.0;
+			double value = atof(token) / 65.0;
 			if (X_AUX_CURRENT_ITEM->number.value != value) {
 				updateInfo = true;
 				X_AUX_CURRENT_ITEM->number.value = value;


### PR DESCRIPTION
According to command table, the readout current value
shall be divided by 600.0, however, when e.g. cooling down
a CCD camera and calculating the current, this would result
in 0.3A. Which is too small. Dividing the value by 65.0 would
give approx. 1.8A which seems to be the proper value.