### PR TITLE
Gitignore indigo_linux_drivers/ccd_gphoto2/externals/libraw/build/

### DIFF
--- a/indigo_linux_drivers/ccd_gphoto2/.gitignore
+++ b/indigo_linux_drivers/ccd_gphoto2/.gitignore
@@ -23,4 +23,4 @@
 /externals/libraw/m4/lt~obsolete.m4
 /externals/libraw/missing
 /externals/libraw/src/.dirstamp
-
+/externals/libraw/build


### PR DESCRIPTION
[skip ci]