### PR TITLE
remove CCD_IMAGE_FILE.FILE tail space

### DIFF
--- a/indigo_libs/indigo/indigo_names.h
+++ b/indigo_libs/indigo/indigo_names.h
@@ -469,7 +469,7 @@
 
 /** CCD_IMAGE_FILE.FILE property item name.
  */
-#define CCD_IMAGE_FILE_ITEM_NAME              "FILE "
+#define CCD_IMAGE_FILE_ITEM_NAME              "FILE"
 
 /** CCD_IMAGE property name.
  */


### PR DESCRIPTION
`CCD_IMAGE_FILE`s `FILE` property is `"FILE "` (NOT `"FILE"`)

```xml
<defTextVector device="Imager Agent" name="CCD_IMAGE_FILE" group="Image" label="Image file info" perm="ro" state="Ok">
	<defText name="FILE " label="Filename">None</defText>
</defTextVector>
```

But I'm concerned about this pull request may cause compatibility problem...
