### PR TITLE
support CCD_PREVIEW_IMAGE for indigo_ccd_gphoto2

### DIFF
--- a/PROPERTIES.md
+++ b/PROPERTIES.md
@@ -87,8 +87,8 @@ Properties are implemented by driver base class in [indigo_driver.c](https://git
 |  |  |  |  | OFF | yes |  |
 | CCD_COOLER_POWER | number | yes | no | POWER | yes | It depends on hardware if it is undefined, read-only or read-write. |
 | CCD_FITS_HEADERS | text | no | yes | HEADER_1, ... | yes | String in form "name = value", "name = 'value'" or "comment text" |
-| CCD_PREVIEW | switch | no | yes | ENABLE | yes | Send JPEG preview to client |
-|  |  |  |  | DISABLE | yes | |
+| CCD_PREVIEW | switch | no | yes | ENABLED | yes | Send JPEG preview to client |
+|  |  |  |  | DISABLED | yes | |
 | CCD_PREVIEW_IMAGE | blob | no | yes | IMAGE | yes |  |
 
 Properties are implemented by CCD driver base class in [indigo_ccd_driver.c](https://github.com/indigo-astronomy/indigo/blob/master/indigo_libs/indigo_ccd_driver.c).

--- a/indigo_libs/indigo/indigo_ccd_driver.h
+++ b/indigo_libs/indigo/indigo_ccd_driver.h
@@ -464,6 +464,8 @@ extern void indigo_process_image(indigo_device *device, void *data, int frame_wi
  */
 extern void indigo_process_dslr_image(indigo_device *device, void *data, int blobsize, const char *suffix);
 
+extern void indigo_process_dslr_preview_image(indigo_device *device, void *data, int blobsize);
+
 #ifdef __cplusplus
 }
 #endif

--- a/indigo_libs/indigo_ccd_driver.c
+++ b/indigo_libs/indigo_ccd_driver.c
@@ -926,7 +926,7 @@ void indigo_process_image(indigo_device *device, void *data, int frame_width, in
 			}
 		}
 	}
-	
+
 	if (CCD_IMAGE_FORMAT_FITS_ITEM->sw.value) {
 		INDIGO_DEBUG(clock_t start = clock());
 		time_t timer;
@@ -1518,4 +1518,20 @@ void indigo_process_dslr_image(indigo_device *device, void *data, int blobsize, 
 		indigo_update_property(device, CCD_IMAGE_PROPERTY, NULL);
 		INDIGO_DEBUG(indigo_debug("Client upload in %gs", (clock() - start) / (double)CLOCKS_PER_SEC));
 	}
+}
+
+void indigo_process_dslr_preview_image(indigo_device *device, void *data, int blobsize) {
+	if (CCD_CONTEXT->preview_image) {
+		if (CCD_CONTEXT->preview_image_size < blobsize) {
+			CCD_CONTEXT->preview_image = realloc(CCD_CONTEXT->preview_image, CCD_CONTEXT->preview_image_size = blobsize);
+		}
+	} else {
+		CCD_CONTEXT->preview_image = malloc(CCD_CONTEXT->preview_image_size = blobsize);
+	}
+	memcpy(CCD_CONTEXT->preview_image, data, blobsize);
+	CCD_PREVIEW_IMAGE_ITEM->blob.value = CCD_CONTEXT->preview_image;
+	CCD_PREVIEW_IMAGE_ITEM->blob.size = blobsize;
+	strcpy(CCD_PREVIEW_IMAGE_ITEM->blob.format, ".jpeg");
+	CCD_PREVIEW_IMAGE_PROPERTY->state = INDIGO_OK_STATE;
+	indigo_update_property(device, CCD_PREVIEW_IMAGE_PROPERTY, NULL);
 }


### PR DESCRIPTION
Support `CCD_PREVIEW_IMAGE` feature in `thread_capture`.

The point is wait for update of file list.

```
		// wait for ready
		// from <https://github.com/jim-easterbrook/python-gphoto2/issues/65>
		CameraEventType event_type = GP_EVENT_UNKNOWN;
		void *event_data = NULL;
		bool added = false;
		while (true) {
			rc = gp_camera_wait_for_event(PRIVATE_DATA->camera, 20, &event_type,
						&event_data, context);
			if (event_type == GP_EVENT_TIMEOUT) {
				break;
			} else if (event_type == GP_EVENT_FILE_ADDED) {
				added = true;
			}
		}
```
