### PR TITLE
Add `indigo_send_device_message()`

### DIFF
--- a/indigo_libs/indigo/indigo_bus.h
+++ b/indigo_libs/indigo/indigo_bus.h
@@ -324,9 +324,12 @@ typedef struct indigo_client {
 	/** callback called when device broadcast property removal
 	 */
 	indigo_result (*delete_property)(indigo_client *client, indigo_device *device, indigo_property *property, const char *message);
-	/** callback called when device broadcast a message
+	/** callback called when device broadcast a generic message
 	 */
 	indigo_result (*send_message)(indigo_client *client, indigo_device *device, const char *message);
+	/** callback called when device broadcast a device message
+	 */
+	indigo_result (*send_device_message)(indigo_client *client, indigo_device *device, const char *message);
 	/** callback called when client is detached from the bus
 	 */
 	indigo_result (*detach)(indigo_client *client);
@@ -429,9 +432,13 @@ extern indigo_result indigo_update_property(indigo_device *device, indigo_proper
  */
 extern indigo_result indigo_delete_property(indigo_device *device, indigo_property *property, const char *format, ...);
 
-/** Broadcast message.
+/** Broadcast generic message.
  */
 extern indigo_result indigo_send_message(indigo_device *device, const char *format, ...);
+
+/** Broadcast device message.
+ */
+extern indigo_result indigo_send_device_message(indigo_device *device, const char *format, ...);
 
 /** Broadcast property enumeration request.
  */
@@ -633,7 +640,7 @@ extern bool indigo_is_sandboxed;
 /** Cache BLOB content
  */
 extern bool indigo_use_blob_caching;
-	
+
 /** Use recursive locks for dispaching all bus messages
  */
 extern bool indigo_use_strict_locking;

--- a/indigo_libs/indigo_driver_json.c
+++ b/indigo_libs/indigo_driver_json.c
@@ -394,7 +394,7 @@ static indigo_result json_message_property(indigo_client *client, indigo_device 
 	int handle = client_context->output;
 	char output_buffer[JSON_BUFFER_SIZE];
 	char *pnt = output_buffer;
-	int size = sprintf(pnt, "{ \"message\": \"%s\" }", message);
+	int size = sprintf(pnt, "{ \"message\": \"%s\", \"device\": \"%s\" }", message, device->name );
 	if (client_context->web_socket)
 		ws_write(handle, output_buffer, size);
 	else

--- a/indigo_libs/indigo_driver_json.c
+++ b/indigo_libs/indigo_driver_json.c
@@ -394,7 +394,7 @@ static indigo_result json_message_property(indigo_client *client, indigo_device 
 	int handle = client_context->output;
 	char output_buffer[JSON_BUFFER_SIZE];
 	char *pnt = output_buffer;
-	int size = sprintf(pnt, "{ \"message\": \"%s\" }", message );
+	int size = sprintf(pnt, "{ \"message\": \"%s\" }", message);
 	if (client_context->web_socket)
 		ws_write(handle, output_buffer, size);
 	else
@@ -415,7 +415,7 @@ static indigo_result json_device_message_property(indigo_client *client, indigo_
 	int handle = client_context->output;
 	char output_buffer[JSON_BUFFER_SIZE];
 	char *pnt = output_buffer;
-	int size = sprintf(pnt, "{ \"message\": \"%s\", \"device\": \"%s\" }", message, device->name );
+	int size = sprintf(pnt, "{ \"message\": \"%s\", \"device\": \"%s\" }", message, device->name);
 	if (client_context->web_socket)
 		ws_write(handle, output_buffer, size);
 	else

--- a/indigo_libs/indigo_driver_xml.c
+++ b/indigo_libs/indigo_driver_xml.c
@@ -281,6 +281,23 @@ static indigo_result xml_device_adapter_send_message(indigo_client *client, indi
 	assert(client_context != NULL);
 	int handle = client_context->output;
 	if (message)
+		indigo_printf(handle, "<message%s/>\n", message_attribute(message));
+	pthread_mutex_unlock(&write_mutex);
+	return INDIGO_OK;
+}
+
+static indigo_result xml_device_adapter_send_device_message(indigo_client *client, indigo_device *device, const char *message) {
+	assert(device != NULL);
+	assert(client != NULL);
+	if (!indigo_reshare_remote_devices && device->is_remote)
+		return INDIGO_OK;
+	if (client->version == INDIGO_VERSION_NONE)
+		return INDIGO_OK;
+	pthread_mutex_lock(&write_mutex);
+	indigo_adapter_context *client_context = (indigo_adapter_context *)client->client_context;
+	assert(client_context != NULL);
+	int handle = client_context->output;
+	if (message)
 		indigo_printf(handle, "<message device='%s'%s/>\n", indigo_xml_escape(device->name), message_attribute(message));
 	pthread_mutex_unlock(&write_mutex);
 	return INDIGO_OK;
@@ -294,6 +311,7 @@ indigo_client *indigo_xml_device_adapter(int input, int ouput) {
 		xml_device_adapter_update_property,
 		xml_device_adapter_delete_property,
 		xml_device_adapter_send_message,
+		xml_device_adapter_send_device_message,
 		NULL
 	};
 	indigo_client *client = malloc(sizeof(indigo_client));

--- a/indigo_libs/indigo_driver_xml.c
+++ b/indigo_libs/indigo_driver_xml.c
@@ -281,7 +281,7 @@ static indigo_result xml_device_adapter_send_message(indigo_client *client, indi
 	assert(client_context != NULL);
 	int handle = client_context->output;
 	if (message)
-		indigo_printf(handle, "<message%s/>\n", message_attribute(message));
+		indigo_printf(handle, "<message device='%s'%s/>\n", indigo_xml_escape(device->name), message_attribute(message));
 	pthread_mutex_unlock(&write_mutex);
 	return INDIGO_OK;
 }
@@ -314,4 +314,3 @@ void indigo_release_xml_device_adapter(indigo_client *client) {
 	free(client->client_context);
 	free(client);
 }
-

--- a/indigo_linux_drivers/ccd_gphoto2/indigo_ccd_gphoto2.c
+++ b/indigo_linux_drivers/ccd_gphoto2/indigo_ccd_gphoto2.c
@@ -1034,7 +1034,7 @@ static void ctx_error_func(GPContext *context, const char *str, void *data)
 	if ( data ) {
 		indigo_device *device = *(indigo_device **)(data);
 		if ( device ) {
-			indigo_send_message(device, "ERROR:%s", str);
+			indigo_send_device_message(device, "ERROR:%s", str);
 		}
 	}
 
@@ -1047,7 +1047,7 @@ static void ctx_status_func(GPContext *context, const char *str, void *data)
 	if ( data ) {
 		indigo_device *device = *(indigo_device **)(data);
 		if ( device ) {
-			indigo_send_message(device, "STATUS:%s", str);
+			indigo_send_device_message(device, "STATUS:%s", str);
 		}
 	}
 

--- a/indigo_linux_drivers/ccd_gphoto2/indigo_ccd_gphoto2.c
+++ b/indigo_linux_drivers/ccd_gphoto2/indigo_ccd_gphoto2.c
@@ -1031,7 +1031,12 @@ cleanup:
 static void ctx_error_func(GPContext *context, const char *str, void *data)
 {
 	UNUSED(context);
-	UNUSED(data);
+	if ( data ) {
+		indigo_device *device = *(indigo_device **)(data);
+		if ( device ) {
+			indigo_send_message(device, "ERROR:%s", str);
+		}
+	}
 
 	INDIGO_DRIVER_ERROR(DRIVER_NAME, "%s", str);
 }
@@ -1039,7 +1044,12 @@ static void ctx_error_func(GPContext *context, const char *str, void *data)
 static void ctx_status_func(GPContext *context, const char *str, void *data)
 {
 	UNUSED(context);
-	UNUSED(data);
+	if ( data ) {
+		indigo_device *device = *(indigo_device **)(data);
+		if ( device ) {
+			indigo_send_message(device, "STATUS:%s", str);
+		}
+	}
 
 	INDIGO_DRIVER_LOG(DRIVER_NAME, "%s", str);
 }
@@ -2757,9 +2767,9 @@ static int device_connect(indigo_device *gphoto2_template,
 	if (!context) {
 		context = gp_context_new();
 		gp_context_set_error_func(context,
-					  ctx_error_func, NULL);
+					  ctx_error_func, &devices[slot]);
 		gp_context_set_message_func(context,
-					    ctx_status_func, NULL);
+					    ctx_status_func, &devices[slot]);
 	}
 
 	/* Allocate memory for camera. */


### PR DESCRIPTION
I need error message that created by gphoto2 callbacks.

But `indigo_send_message` send a *generic system message* (defined at INDI protocol v1.7 
Example Messages from Device to Client).

```
<message message="ERROR:Canon EOS Capture failed to release: Perhaps no more memory on card?"/>
```

I want to identify the message from which device.

```
<message device="Canon EOS 40D (PTP mode)" message="ERROR:Canon EOS Capture failed to release: Perhaps no more memory on card?"/>
```
