### PR TITLE
fix temma version parsing

### DIFF
--- a/indigo_drivers/mount_temma/indigo_mount_temma.c
+++ b/indigo_drivers/mount_temma/indigo_mount_temma.c
@@ -189,9 +189,13 @@ static bool temma_command(indigo_device *device, char *command, bool wait) {
 				break;
 			}
 			case 'v': {
-				strncpy(MOUNT_INFO_VENDOR_ITEM->text.value, "Takahashi", INDIGO_VALUE_SIZE);
-				strncpy(MOUNT_INFO_MODEL_ITEM->text.value, buffer + 4, INDIGO_VALUE_SIZE);
-				strncpy(MOUNT_INFO_FIRMWARE_ITEM->text.value, "N/A", INDIGO_VALUE_SIZE);
+				switch (buffer[1]) {
+					case 'e':
+						strncpy(MOUNT_INFO_VENDOR_ITEM->text.value, "Takahashi", INDIGO_VALUE_SIZE);
+						strncpy(MOUNT_INFO_MODEL_ITEM->text.value, buffer + 4, INDIGO_VALUE_SIZE);
+						strncpy(MOUNT_INFO_FIRMWARE_ITEM->text.value, "N/A", INDIGO_VALUE_SIZE);
+						break;
+				};
 				break;
 			}
 			case 's': {


### PR DESCRIPTION
fix broken MOUNT_INFO.MODEL

caused by `v1`, `v2` response.
