### PR TITLE
Add Temma commands

### DIFF
--- a/indigo_drivers/mount_temma/indigo_mount_temma.c
+++ b/indigo_drivers/mount_temma/indigo_mount_temma.c
@@ -616,6 +616,7 @@ static indigo_result mount_change_property(indigo_device *device, indigo_client 
 					INDIGO_DRIVER_DEBUG(DRIVER_NAME, "Side of pier switched : East -> West");
 				}
 			}
+			indigo_update_property(device, MOUNT_SIDE_OF_PIER_PROPERTY, NULL);
 		}
 		return INDIGO_OK;
 	} else if (indigo_property_match(CORRECTION_SPEED_PROPERTY, property)) {
@@ -671,6 +672,7 @@ static indigo_result mount_change_property(indigo_device *device, indigo_client 
 				// show ok
 				ZENITH_PROPERTY->state = INDIGO_OK_STATE;
 				indigo_update_property(device, ZENITH_PROPERTY, NULL);
+				indigo_update_property(device, MOUNT_SIDE_OF_PIER_PROPERTY, NULL);
 			}
 		}
 		return INDIGO_OK;


### PR DESCRIPTION
Added new advanced property:

* `X_ZENITH`: Sync at zenith
    * `EAST`: East side (To look at the west sky)
    * `WEST`: West side (To look at the east sky)
* `X_HIGHSPEED`
    * `LOW`: Drive with low speed
    * `HIGH`: Drive with high speed

And added standard property:

* `SIDE_OF_PIER`

Above properties tested with 

* Temma PC
* Temma 2M

## About `X_ZENITH`

`Z` command means "sync with Zenith".

This position (see the below image) is Takahashi Temma's standard initial position.

![setuptelescope4](https://user-images.githubusercontent.com/54392213/71075429-5f578080-21c7-11ea-9572-4a2d87508703.png)

## About `X_HIGHSPEED`

Temma2M and later models can move at high speed with 12V.
However, the previous model will step out if it is not a 24V power supply.
It is desirable to set the default to a low speed and switch to a high speed as necessary.

Command\Model | Temma PC | Temma 2M (or later)
-----|-----|-----
`LOW` == `v1` | low speed & requires 12V | low speed & requires 12V
`HIGH` == `v2` | high speed & requires 24V | high speed & requires **12V** (but requires more current)
