### PR TITLE
Add busy state for indigo_ccd_gphoto2

### DIFF
--- a/indigo_linux_drivers/ccd_gphoto2/indigo_ccd_gphoto2.c
+++ b/indigo_linux_drivers/ccd_gphoto2/indigo_ccd_gphoto2.c
@@ -1707,6 +1707,8 @@ static void update_property(indigo_device *device, indigo_property *property,
 
 	for (int p = 0; p < property->count; p++) {
 		if (property->items[p].sw.value) {
+			property->state = INDIGO_BUSY_STATE;
+			indigo_update_property(device, property, NULL);
 			rc = gphoto2_set_key_val_char(widget,
 						      property->items[p].name,
 						      device);


### PR DESCRIPTION
Add busy state notify.

`gphoto2_set_key_val_char()` takes a long time to change SONY camera settings.

Setting | Time
----------|----------
ISO 100 to ISO 409600 | 30sec
1/8000 to 30" | 50sec