### PR TITLE
fix PTP transaction for USB 3.0 protocol

### DIFF
--- a/indigo_drivers/ccd_ptp/indigo_ptp.h
+++ b/indigo_drivers/ccd_ptp/indigo_ptp.h
@@ -282,7 +282,7 @@ typedef struct {
 	uint32_t transaction_id;
 	union {
 		uint32_t params[5];
-		uint8_t data[512 - PTP_CONTAINER_HDR_SIZE];
+		uint8_t data[1024 - PTP_CONTAINER_HDR_SIZE];
 	} payload;
 } ptp_container;
 


### PR DESCRIPTION
`LIBUSB_ERROR_OVERFLOW` occured when connect EOS Ra with USB 3.0 cable.

```
20:05:04.065617 indigo_server: indigo_ccd_ptp[ptp_open:783]: libusb_get_device_descriptor() -> OK
20:05:04.065649 indigo_server: indigo_ccd_ptp[ptp_open:786]: libusb_open() -> OK
20:05:04.065657 indigo_server: indigo_ccd_ptp[ptp_open:797]: libusb_get_config_descriptor(0) -> OK
20:05:04.065661 indigo_server: indigo_ccd_ptp[ptp_open:803]: PTP CONFIG = 1 IFACE = 0
20:05:04.066280 indigo_server: indigo_ccd_ptp[ptp_open:816]: libusb_set_configuration(1) -> OK
20:05:04.066325 indigo_server: indigo_ccd_ptp[ptp_open:821]: libusb_claim_interface(0) -> OK
20:05:04.066549 indigo_server: indigo_ccd_ptp[ptp_open:848]: PTP EP OUT = 01 IN = 82 INT = 83
20:05:04.066562 indigo_server: indigo_ccd_ptp[872, ptp_transaction]: request OpenSession (1002) 00000000 [00000001]
20:05:04.073335 indigo_server: indigo_ccd_ptp[ptp_transaction:874]: libusb_bulk_transfer(0) -> LIBUSB_ERROR_IO
20:05:04.073423 indigo_server: indigo_ccd_ptp[ptp_transaction:877]: libusb_clear_halt() -> OK
20:05:04.073508 indigo_server: indigo_ccd_ptp[ptp_transaction:879, 0x7feb8a7f2700]: libusb_bulk_transfer(16) -> OK
20:05:04.075404 indigo_server: indigo_ccd_ptp[ptp_transaction:914]: libusb_bulk_transfer() -> OK, 12
20:05:04.075429 indigo_server: indigo_ccd_ptp[924, ptp_transaction]: response OK (2001) 00000000 []
20:05:04.075459 indigo_server: indigo_ccd_ptp[872, ptp_transaction]: request GetDeviceInfo (1001) 00000001 []
20:05:04.075516 indigo_server: indigo_ccd_ptp[ptp_transaction:874]: libusb_bulk_transfer(12) -> OK
20:05:04.077507 indigo_server: indigo_ccd_ptp[ptp_transaction:914]: libusb_bulk_transfer() -> LIBUSB_ERROR_OVERFLOW, 0
20:05:04.077520 indigo_server: indigo_ccd_ptp[ptp_transaction:916, 0x7feb8a7f2700]: Failed to read response -> LIBUSB_ERROR_OVERFLOW
20:05:04.077618 indigo_server: indigo_ccd_ptp[ptp_close:982]: libusb_close()
```

ref: https://github.com/hanwen/go-mtpfs/issues/130#issuecomment-440922161

> This error occurs because USB 3 increased the maximum bulk transfer size to 1024 bytes
