### PR TITLE
Fix gps:// offset length.

### DIFF
--- a/indigo_drivers/gps_nmea/indigo_gps_nmea.c
+++ b/indigo_drivers/gps_nmea/indigo_gps_nmea.c
@@ -55,7 +55,7 @@ static bool gps_open(indigo_device *device) {
 	if (strncmp(name, "gps://", 6)) {
 		PRIVATE_DATA->handle = indigo_open_serial_with_config(name, DEVICE_BAUDRATE_ITEM->text.value);
 	} else {
-		char *host = name + 8;
+		char *host = name + 6;
 		char *colon = strchr(host, ':');
 		if (colon == NULL) {
 			PRIVATE_DATA->handle = indigo_open_tcp(host, 9999);


### PR DESCRIPTION
Hostnames were getting truncated because of the offset length mismatch.