### PR TITLE
ccd_ptp: Add boot wait for SONY a7II and a7S

### DIFF
--- a/indigo_drivers/ccd_ptp/indigo_ptp_sony.c
+++ b/indigo_drivers/ccd_ptp/indigo_ptp_sony.c
@@ -684,6 +684,7 @@ bool ptp_sony_initialise(indigo_device *device) {
 			for (uint16_t *property = properties; *property; property++) {
 				INDIGO_LOG(indigo_log("  %04x %s", *property, ptp_property_sony_code_label(*property)));
 			}
+			// SONY a7II and a7S need to wait to boot
 			indigo_usleep(ONE_SECOND_DELAY);
 			ptp_transaction_3_0(device, ptp_operation_sony_SDIOConnect, 3, 0, 0);
 			if (ptp_transaction_0_0_i(device, ptp_operation_sony_GetAllDevicePropData, &buffer, &size)) {

--- a/indigo_drivers/ccd_ptp/indigo_ptp_sony.c
+++ b/indigo_drivers/ccd_ptp/indigo_ptp_sony.c
@@ -684,6 +684,7 @@ bool ptp_sony_initialise(indigo_device *device) {
 			for (uint16_t *property = properties; *property; property++) {
 				INDIGO_LOG(indigo_log("  %04x %s", *property, ptp_property_sony_code_label(*property)));
 			}
+			indigo_usleep(ONE_SECOND_DELAY);
 			ptp_transaction_3_0(device, ptp_operation_sony_SDIOConnect, 3, 0, 0);
 			if (ptp_transaction_0_0_i(device, ptp_operation_sony_GetAllDevicePropData, &buffer, &size)) {
 				uint8_t *source = buffer;


### PR DESCRIPTION
SONY α7II and α7S reboot due to sending `ptp_operation_sony_SDIOConnect`.
refs: https://github.com/indigo-astronomy/indigo/issues/271#issuecomment-573026492
