### PR TITLE
Nikon Z 50 support

### DIFF
--- a/indigo_drivers/ccd_ptp/indigo_ptp.c
+++ b/indigo_drivers/ccd_ptp/indigo_ptp.c
@@ -856,6 +856,39 @@ bool ptp_open(indigo_device *device) {
 	return rc >= 0;
 }
 
+uint32_t ptp_type_size(ptp_type type) {
+	switch (type) {
+	case ptp_int8_type:
+	case ptp_uint8_type:
+		return 1;
+	case ptp_int16_type:
+	case ptp_uint16_type:
+		return 2;
+	case ptp_int32_type:
+	case ptp_uint32_type:
+		return 4;
+	case ptp_int64_type:
+	case ptp_uint64_type:
+		return 8;
+	case ptp_int128_type:
+	case ptp_uint128_type:
+		return 16;
+	// array of integers
+	case ptp_aint8_type:
+	case ptp_auint8_type:
+	case ptp_aint16_type:
+	case ptp_auint16_type:
+	case ptp_aint32_type:
+	case ptp_auint32_type:
+	case ptp_aint64_type:
+	case ptp_auint64_type:
+	case ptp_aint128_type:
+	case ptp_auint128_type:
+	default:
+		return 0;
+	}
+}
+
 bool ptp_transaction(indigo_device *device, uint16_t code, int count, uint32_t out_1, uint32_t out_2, uint32_t out_3, uint32_t out_4, uint32_t out_5, void *data_out, uint32_t data_out_size, uint32_t *in_1, uint32_t *in_2, uint32_t *in_3, uint32_t *in_4, uint32_t *in_5, void **data_in, uint32_t *data_in_size) {
 	pthread_mutex_lock(&PRIVATE_DATA->usb_mutex);
 	if (PRIVATE_DATA->handle == NULL)
@@ -1253,7 +1286,7 @@ bool ptp_set_property(indigo_device *device, ptp_property *property) {
 				uint8_t *end = ptp_encode_string(property->value.sw_str.value, buffer);
 				return ptp_transaction_0_1_o(device, ptp_operation_SetDevicePropValue, property->code, buffer, (uint32_t)(end - buffer));
 			}
-			return ptp_transaction_0_1_o(device, ptp_operation_SetDevicePropValue, property->code, &property->value.number.value, sizeof(uint32_t));
+			return ptp_transaction_0_1_o(device, ptp_operation_SetDevicePropValue, property->code, &property->value.number.value, ptp_type_size(property->type));
 		}
 		case INDIGO_NUMBER_VECTOR: {
 			property->value.number.value = property->property->items->number.target;

--- a/indigo_drivers/ccd_ptp/indigo_ptp.c
+++ b/indigo_drivers/ccd_ptp/indigo_ptp.c
@@ -271,14 +271,20 @@ char *ptp_property_value_code_label(indigo_device *device, uint16_t property, ui
 				return "Time";
 			if (code == 1)
 				return "1/8000s";
+			if (code == 2)
+				return "1/4000s";
 			if (code == 3)
 				return "1/3200s";
 			if (code == 6)
 				return "1/1600s";
 			if (code == 12)
 				return "1/800s";
+			if (code == 13)
+				return "1/750s";
 			if (code == 15)
 				return "1/640s";
+			if (code == 28)
+				return "1/350s";
 			if (code == 80)
 				return "1/125s";
 			if (code < 100) {
@@ -286,7 +292,15 @@ char *ptp_property_value_code_label(indigo_device *device, uint16_t property, ui
 				return label;
 			}
 			if (code < 10000) {
-				sprintf(label, "1/%gs", round(10000.0 / code));
+				double fraction = 10000.0 / code;
+				double integral_part = 0.0;
+				double fraction_part = modf(fraction, &integral_part);
+				if (fraction_part >= 0.1 && integral_part < 10) {
+					// for 1/2.5s, 1/1.6s, 1/1.3s
+					sprintf(label, "1/%.1fs", fraction);
+				} else {
+					sprintf(label, "1/%gs", round(fraction));
+				}
 				return label;
 			}
 			sprintf(label, "%gs", code / 10000.0);

--- a/indigo_drivers/ccd_ptp/indigo_ptp_nikon.c
+++ b/indigo_drivers/ccd_ptp/indigo_ptp_nikon.c
@@ -73,7 +73,7 @@
 	PRIVATE_DATA->model.product == NIKON_PRODUCT_Z6 || \
 	PRIVATE_DATA->model.product == NIKON_PRODUCT_Z50
 
-#define IS_NIKON_EXSPEED5_OR_LATER() \
+#define IS_NIKON_EXPEED5_OR_LATER() \
 	IS_NIKON_EXPEED5_SERIES() || \
 	IS_NIKON_EXPEED6_SERIES()
 
@@ -474,7 +474,7 @@ char *ptp_property_nikon_value_code_label(indigo_device *device, uint16_t proper
 	static char label[PTP_MAX_CHARS];
 	switch (property) {
 		case ptp_property_CompressionSetting: {
-			if (IS_NIKON_EXSPEED5_OR_LATER()) {
+			if (IS_NIKON_EXPEED5_OR_LATER()) {
 				switch (code) { case 0: return "JPEG basic"; case 1: return "JPEG basic *"; case 2: return "JPEG normal"; case 3: return "JPEG normal *"; case 4: return "JPEG fine"; case 5: return "JPEG  fine *"; case 6: return "TIFF (RGB)"; case 7: return "NEF"; case 8: return "NEF + JPEG basic"; case 9: return "NEF + JPEG basic *"; case 10: return "NEF + JPEG normal"; case 11: return "NEF + JPEG normal *"; case 12: return "NEF + JPEG fine"; case 13: return "NEF + JPEG fine *"; }
 			} else {
 				switch (code) { case 0: return "JPEG Basic"; case 1: return "JPEG Norm"; case 2: return "JPEG Fine"; case 3:return "TIFF-RGB"; case 4: return "RAW"; case 5: return "RAW + JPEG Basic"; case 6: return "RAW + JPEG Norm"; case 7: return "RAW + JPEG Fine"; }
@@ -999,7 +999,7 @@ bool ptp_nikon_fix_property(indigo_device *device, ptp_property *property) {
 			return true;
 		}
 		case ptp_property_CompressionSetting: {
-			if (IS_NIKON_EXSPEED5_OR_LATER())
+			if (IS_NIKON_EXPEED5_OR_LATER())
 				NIKON_PRIVATE_DATA->is_dual_compression = property->value.sw.value >= 8 && property->value.sw.value <= 13;
 			else
 				NIKON_PRIVATE_DATA->is_dual_compression = property->value.sw.value >= 5 && property->value.sw.value <= 7;
@@ -1012,7 +1012,7 @@ bool ptp_nikon_fix_property(indigo_device *device, ptp_property *property) {
 bool ptp_nikon_set_property(indigo_device *device, ptp_property *property) {
 	bool result = ptp_set_property(device, property);
 	if (property->code == ptp_property_CompressionSetting) {
-		if (IS_NIKON_EXSPEED5_OR_LATER())
+		if (IS_NIKON_EXPEED5_OR_LATER())
 			NIKON_PRIVATE_DATA->is_dual_compression = property->value.sw.value >= 8 && property->value.sw.value <= 13;
 		else
 			NIKON_PRIVATE_DATA->is_dual_compression = property->value.sw.value >= 5 && property->value.sw.value <= 7;

--- a/indigo_drivers/ccd_ptp/indigo_ptp_nikon.c
+++ b/indigo_drivers/ccd_ptp/indigo_ptp_nikon.c
@@ -490,7 +490,7 @@ char *ptp_property_nikon_value_code_label(indigo_device *device, uint16_t proper
 			return label;
 		}
 		case ptp_property_StillCaptureMode: {
-			switch (code) { case 1: return "Single shot"; case 2: return "Continuous"; case 3:return "Timelapse"; case 32784: return "Continuous low speed"; case 32785: return "Timer"; case 32786: return "Mirror up"; case 32787: return "Remote"; case 32788: return "Timer + Remote"; case 32789: return "Delayed remote"; case 32790: return "Quiet shutter release"; }
+			switch (code) { case 1: return "Single shot"; case 2: return "Continuous"; case 3:return "Timelapse"; case 32784: return "Continuous low speed"; case 32785: return "Timer"; case 32786: return "Mirror up"; case 32787: return "Remote"; case 32788: return "Timer + Remote"; case 32789: return "Delayed remote"; case 32790: return "Quiet shutter release"; case 32793: return "Continuous *"; }
 			break;
 		}
 		case ptp_property_FocusMeteringMode: {
@@ -610,7 +610,7 @@ char *ptp_property_nikon_value_code_label(indigo_device *device, uint16_t proper
 			break;
 		}
 		case ptp_property_nikon_ActivePicCtrlItem: {
-			switch (code) { case 0: return "Undefined"; case 1: return "Standard"; case 2: return "Neutral"; case 3: return "Vivid"; case 4: return "Monochrome"; case 5: return "Portrait"; case 6: return "Landscape"; case 7: return "Flat"; case 201: return "Custom 1"; case 202: return "Custom 2"; case 203: return "Custom 3"; case 204: return "Custom 4"; case 205: return "Custom 5"; case 206: return "Custom 6"; case 207: return "Custom 7"; case 208: return "Custom 8"; case 209: return "Custom 9"; }
+			switch (code) { case 0: return "Undefined"; case 1: return "Standard"; case 2: return "Neutral"; case 3: return "Vivid"; case 4: return "Monochrome"; case 5: return "Portrait"; case 6: return "Landscape"; case 7: return "Flat"; case 8: return "Auto"; case 101: return "Dream"; case 102: return "Morning"; case 103: return "Pop"; case 104: return "Sunday"; case 105: return "Somber"; case 106: return "Dramatic"; case 107: return "Silence"; case 108: return "Bleached"; case 109: return "Melancholic"; case 110: return "Pure"; case 111: return "Denim"; case 112: return "Toy"; case 113: return "Sepia"; case 114: return "Blue"; case 115: return "Red"; case 116: return "Pink"; case 117: return "Charcoal"; case 118: return "Graphite"; case 119: return "Binary"; case 120: return "Carbon"; case 201: return "Custom 1"; case 202: return "Custom 2"; case 203: return "Custom 3"; case 204: return "Custom 4"; case 205: return "Custom 5"; case 206: return "Custom 6"; case 207: return "Custom 7"; case 208: return "Custom 8"; case 209: return "Custom 9"; }
 			break;
 		}
 		case ptp_property_nikon_EffectMode: {


### PR DESCRIPTION
Update property label for Z 50.

And fixed SetDevicePropValue when using switch.
Nikon Z 50 requires exact size of sending data.

```
18:03:34.570374 indigo_server: indigo_ccd_ptp[ptp_transaction:896]: request SetDevicePropValue (1016) 00000109 [0000500f]
18:03:34.570444 indigo_server: indigo_ccd_ptp[ptp_transaction:898]: libusb_bulk_transfer(16) -> OK
18:03:34.570454 indigo_server: indigo_ccd_ptp[ptp_transaction:914]: data 1016 00000109 +4 bytes
18:03:34.580290 indigo_server: indigo_ccd_ptp[ptp_transaction:938]: libusb_bulk_transfer() -> OK, 12
18:03:34.580309 indigo_server: indigo_ccd_ptp[ptp_transaction:948]: response InvalidDevicePropFormat (201b) 00000109 []
```