### PR TITLE
ccd_ptp: fix connection problem

### DIFF
--- a/indigo_drivers/ccd_ptp/indigo_ptp.c
+++ b/indigo_drivers/ccd_ptp/indigo_ptp.c
@@ -835,16 +835,13 @@ bool ptp_open(indigo_device *device) {
 				int address = ep[i].bEndpointAddress;
 				if ((address & LIBUSB_ENDPOINT_DIR_MASK) == LIBUSB_ENDPOINT_IN) {
 					PRIVATE_DATA->ep_in = address;
-					libusb_clear_halt(handle, address);
 				} else if ((address & LIBUSB_ENDPOINT_DIR_MASK) == LIBUSB_ENDPOINT_OUT) {
 					PRIVATE_DATA->ep_out = address;
-					libusb_clear_halt(handle, address);
 				}
 			} else if (ep[i].bmAttributes == LIBUSB_TRANSFER_TYPE_INTERRUPT) {
 				int address = ep[i].bEndpointAddress;
 				if ((address & LIBUSB_ENDPOINT_DIR_MASK) == LIBUSB_ENDPOINT_IN) {
 					PRIVATE_DATA->ep_int = address;
-					libusb_clear_halt(handle, address);
 				}
 			}
 		}

--- a/indigo_drivers/ccd_ptp/indigo_ptp.c
+++ b/indigo_drivers/ccd_ptp/indigo_ptp.c
@@ -810,11 +810,12 @@ bool ptp_open(indigo_device *device) {
 		libusb_free_config_descriptor(config_descriptor);
 		config_descriptor = NULL;
 	}
-	if (rc >= 0 && config_descriptor) {
-		int configuration_value = config_descriptor->bConfigurationValue;
-		rc = libusb_set_configuration(handle, configuration_value);
-		INDIGO_DRIVER_DEBUG(DRIVER_NAME, "libusb_set_configuration(%d) -> %s", configuration_value, rc < 0 ? libusb_error_name(rc) : "OK");
-	}
+// Already sent OpenSession
+//	if (rc >= 0 && config_descriptor) {
+//		int configuration_value = config_descriptor->bConfigurationValue;
+//		rc = libusb_set_configuration(handle, configuration_value);
+//		INDIGO_DRIVER_DEBUG(DRIVER_NAME, "libusb_set_configuration(%d) -> %s", configuration_value, rc < 0 ? libusb_error_name(rc) : "OK");
+//	}
 	if (rc >= 0 && interface) {
 		int interface_number = interface->altsetting->bInterfaceNumber;
 		rc = libusb_claim_interface(handle, interface_number);


### PR DESCRIPTION
* Nikon D5300 will busy when sending `libusb_clear_halt` while connecting. #276
* SONY a7SII will busy when sending OpenSession twice. #290
