### PR TITLE
Nikon Z 7 & Z 6 support

### DIFF
--- a/indigo_drivers/ccd_ptp/indigo_ptp.c
+++ b/indigo_drivers/ccd_ptp/indigo_ptp.c
@@ -612,7 +612,20 @@ uint8_t *ptp_decode_property(uint8_t *source, indigo_device *device, ptp_propert
 			source = ptp_decode_string(source, target->value.text.value);
 			break;
 		}
+		case ptp_aint8_type:
+		case ptp_auint8_type:
+		case ptp_aint16_type:
+		case ptp_auint16_type:
+		case ptp_aint32_type:
+		case ptp_auint32_type:
+		case ptp_aint64_type:
+		case ptp_auint64_type:
+		case ptp_aint128_type:
+		case ptp_auint128_type:
+			INDIGO_LOG(indigo_log("code:%x is array type(%x)", target->code, target->type));
+			return;
 		default:
+			INDIGO_LOG(indigo_log("Unsupported type=%x", target->type));
 			assert(false);
 	}
 	source = ptp_decode_uint8(source, &target->form);

--- a/indigo_drivers/ccd_ptp/indigo_ptp_nikon.c
+++ b/indigo_drivers/ccd_ptp/indigo_ptp_nikon.c
@@ -502,7 +502,7 @@ char *ptp_property_nikon_value_code_label(indigo_device *device, uint16_t proper
 			break;
 		}
 		case ptp_property_WhiteBalance: {
-			switch (code) { case 1: return "Manual"; case 2: return "Auto"; case 3: return "One-push Auto"; case 4: return "Daylight"; case 5: return "Fluorescent"; case 6: return "Incandescent"; case 7: return "Flash"; case 32784: return "Cloudy"; case 32785: return "Shade"; case 32786: return "Color Temperature"; case 32787: return "Preset"; }
+			switch (code) { case 1: return "Manual"; case 2: return "Auto"; case 3: return "One-push Auto"; case 4: return "Daylight"; case 5: return "Fluorescent"; case 6: return "Incandescent"; case 7: return "Flash"; case 32784: return "Cloudy"; case 32785: return "Shade"; case 32786: return "Color Temperature"; case 32787: return "Preset"; case 32790: return "Natural light auto"; }
 			break;
 		}
 		case ptp_property_nikon_ExternalFlashMode:


### PR DESCRIPTION
Nikon Z 7 & Z 6 has the property of uint8 array. (code:`d1fd`)
It should be ignored to avoid crashing with assertions.