### PR TITLE
mount_temma: The Z command requires LST

### DIFF
--- a/indigo_drivers/mount_temma/indigo_mount_temma.c
+++ b/indigo_drivers/mount_temma/indigo_mount_temma.c
@@ -706,6 +706,7 @@ static indigo_result mount_change_property(indigo_device *device, indigo_client 
 					temma_command(device, TEMMA_SWITCH_SIDE_OF_MOUNT, false);
 				}
 				// send zenith
+				temma_set_lst(device);
 				temma_command(device, TEMMA_ZENITH, false);
 				ZENITH_EAST_ITEM->sw.value = false;
 				ZENITH_WEST_ITEM->sw.value = false;


### PR DESCRIPTION
If synchronize the zenith again after some time, it will be synchronized away from the zenith.
It seems to require an LST before sending the Z command.
