### PR TITLE
Added support for Pegasus Powerbox Advance to the existing PPB driver

### DIFF
--- a/indigo_drivers/aux_ppb/README.md
+++ b/indigo_drivers/aux_ppb/README.md
@@ -4,6 +4,7 @@ https://pegasusastro.com/products/pocket-powerbox/
 
 ## Supported devices
 * PegasusAstro Pocket Powerbox
+* PegasusAstro Pocket Powerbox Advance
 
 Single device is present on startup (no hot-plug support).
 

--- a/indigo_drivers/aux_ppb/indigo_aux_ppb.c
+++ b/indigo_drivers/aux_ppb/indigo_aux_ppb.c
@@ -140,7 +140,7 @@ static indigo_result aux_attach(indigo_device *device) {
 		indigo_init_switch_item(AUX_POWER_OUTLET_2_ITEM, AUX_POWER_OUTLET_2_ITEM_NAME, "DSLR outlet", true); // In PPBA this can be 0 or 1, but can ALSO be set to variable power 3, 5, 8, 9 or 12 [Volts].
 
 		// PPBA ONLY
-		AUX_POWER_OUTLET_STATE_PROPERTY = indigo_init_light_property(NULL, device->name, AUX_POWER_OUTLET_STATE_PROPERTY_NAME, AUX_GROUP, "Power outlets state", INDIGO_OK_STATE, 4);
+		AUX_POWER_OUTLET_STATE_PROPERTY = indigo_init_light_property(NULL, device->name, AUX_POWER_OUTLET_STATE_PROPERTY_NAME, AUX_GROUP, "Power outlets state", INDIGO_OK_STATE, 1);
 		if (AUX_POWER_OUTLET_STATE_PROPERTY == NULL)
 			return INDIGO_FAILED;
 		indigo_init_light_item(AUX_POWER_OUTLET_STATE_1_ITEM, AUX_POWER_OUTLET_STATE_1_ITEM_NAME, "Power warning state", INDIGO_OK_STATE);

--- a/indigo_drivers/aux_ppb/indigo_aux_ppb.c
+++ b/indigo_drivers/aux_ppb/indigo_aux_ppb.c
@@ -427,6 +427,7 @@ static void aux_connection_handler(indigo_device *device) {
 				strcpy(INFO_DEVICE_FW_REVISION_ITEM->text.value, response);
 				indigo_update_property(device, INFO_PROPERTY, NULL);
 			}
+			ppb_command(device, "PL:1", response, sizeof(response));
 			indigo_define_property(device, AUX_POWER_OUTLET_PROPERTY, NULL);
 			indigo_define_property(device, AUX_HEATER_OUTLET_PROPERTY, NULL);
 			indigo_define_property(device, AUX_DEW_CONTROL_PROPERTY, NULL);

--- a/indigo_drivers/aux_ppb/indigo_aux_ppb_main.c
+++ b/indigo_drivers/aux_ppb/indigo_aux_ppb_main.c
@@ -18,7 +18,7 @@
 
 // version history
 // 2.0 by Peter Polakovic <peter.polakovic@cloudmakers.eu>
-// 2.0.1 Added support for Pocket Powerbox Advanced
+// 2020-07-27 by Aaron Freimark <abf@mac.com> added support for Pocket Powerbox Advance
 
 /** INDIGO PegasusAstro PPB aux driver main
  \file indigo_aux_ppb_main.c

--- a/indigo_drivers/aux_ppb/indigo_aux_ppb_main.c
+++ b/indigo_drivers/aux_ppb/indigo_aux_ppb_main.c
@@ -18,6 +18,7 @@
 
 // version history
 // 2.0 by Peter Polakovic <peter.polakovic@cloudmakers.eu>
+// 2.0.1 Added support for Pocket Powerbox Advanced
 
 /** INDIGO PegasusAstro PPB aux driver main
  \file indigo_aux_ppb_main.c

--- a/indigo_drivers/aux_ppb/ppb_simulator/ppb_simulator.ino
+++ b/indigo_drivers/aux_ppb/ppb_simulator/ppb_simulator.ino
@@ -22,6 +22,8 @@
 #define Serial SerialUSB
 #endif
 
+#define PPBA
+
 bool power1 = true;
 bool power2 = true;
 bool power3 = true;
@@ -30,6 +32,10 @@ byte power5 = 0;
 byte power6 = 0;
 bool power_dslr = true;
 bool autodev = true;
+#ifdef PPBA
+    bool power_alert = 0;
+    int power_adj = 5;
+#endif
 
 void setup() {
   Serial.begin(9600);
@@ -41,7 +47,11 @@ void setup() {
 void loop() {
   String command = Serial.readStringUntil('\n');
   if (command.equals("P#")) {
+#ifdef PPBA
     Serial.println("PPB_OK");
+#else
+    Serial.println("PPBA_OK");
+#endif
   } else if (command.startsWith("PE:")) {
     power1 = command.charAt(3) == '1';
     power2 = command.charAt(4) == '1';
@@ -63,7 +73,11 @@ void loop() {
   } else if (command.startsWith("PF")) {
     Serial.println("RBT");
   } else if (command.startsWith("PA")) {
+#ifdef PPBA
     Serial.print("PPB:12.2:");
+#else
+    Serial.println("PPBA:12.2:");
+#endif
     Serial.print((power1 || power2 || power3 || power4) * 2 + 3 * (power5 + power6) / 255 + power_dslr);
     Serial.print(".0:23.2:59:14.7:");
     Serial.print(power1 + power2 + power3 + power4 ? '1' : '0');
@@ -75,6 +89,11 @@ void loop() {
     Serial.print(power6);
     Serial.print(':');
     Serial.println(autodev ? '1' : '0');
+#ifdef PPBA
+    Serial.print(power_alert);
+    Serial.print(':');
+    Serial.print(power_adj);
+#endif
   } else if (command.startsWith("PD:")) {
     autodev = command.charAt(3) == '1';
     Serial.println(command);


### PR DESCRIPTION
I made changes as requested. Now, instead of a new driver, I extended the aux_ppb driver to detect both standard and "Advance" versions of the Pegasus Powerbox. I have tested this with my own PPBA, but I do not have a PPB to test with. 

Feedback is more than welcome!