### PR TITLE
Fix for issue 432: changed CPU architectture detection logic in ./Mak…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,12 +107,15 @@ else
 			DEBIAN_ARCH = i386
 		endif
 		ifeq ($(ARCH_DETECTED),x86_64)
-			ifeq ($(wildcard /lib/x86_64-linux-gnu/),)
-				ARCH_DETECTED = x86
-				DEBIAN_ARCH = i386
-			else
+			ifneq ($(wildcard /lib/x86_64-linux-gnu/),)
 				ARCH_DETECTED = x64
 				DEBIAN_ARCH = amd64
+			else ifneq ($(wildcard /lib64/),)
+				ARCH_DETECTED = x64
+				DEBIAN_ARCH = amd64
+			else
+				ARCH_DETECTED = x86
+				DEBIAN_ARCH = i386
 			endif
 		endif
 		CC = gcc

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ It is advised to remove libraw1394-dev
 
 #### Fedora
 
-`dnf install automake autoconf cmake libtool gcc gcc-c++ libusb-devel avahi-compat-libdns_sd-devel libudev-devel git curl`
+`dnf install automake autoconf cmake libtool gcc gcc-c++ libusb-devel avahi-compat-libdns_sd-devel libudev-devel git curl curl-devel`
 
 It is advised to remove libraw1394-devel
 

--- a/indigo_drivers/ccd_qhy/bin_externals/pthread_yield_compat/Makefile
+++ b/indigo_drivers/ccd_qhy/bin_externals/pthread_yield_compat/Makefile
@@ -40,12 +40,15 @@ ifeq ($(OS_DETECTED),Linux)
 		DEBIAN_ARCH = i386
 	endif
 	ifeq ($(ARCH_DETECTED),x86_64)
-		ifeq ($(wildcard /lib/x86_64-linux-gnu/),)
-			ARCH_DETECTED = x86
-			DEBIAN_ARCH = i386
-		else
+		ifneq ($(wildcard /lib/x86_64-linux-gnu/),)
 			ARCH_DETECTED = x64
 			DEBIAN_ARCH = amd64
+		else ifneq ($(wildcard /lib64/),)
+			ARCH_DETECTED = x64
+			DEBIAN_ARCH = amd64
+		else
+			ARCH_DETECTED = x86
+			DEBIAN_ARCH = i386
 		endif
 	endif
 	CC = gcc


### PR DESCRIPTION
Fix for issue 432:  modified ./Makefile and ./indigo_drivers/ccd_qhy/bin_externals/pthread_yield_compat/Makefile, in order to work for x86_64 CPU architecture under Fedora. 

Also, updated README.md to include curl-devel as a prerequisite for Fedora (includes libcurl.so, which is otherwise missing)