### PR TITLE
ccd_ptp: remove Canon EOS M6

### DIFF
--- a/data/dslr.csv
+++ b/data/dslr.csv
@@ -38,7 +38,6 @@ Canon, 0x32a1, "Canon EOS 750D", ptp_flag_lv, 6000, 4000, 3.71, Canon EOS Kiss X
 Canon, 0x32af, "Canon EOS 5DSR", ptp_flag_lv, 8688, 5792, 4.14,,
 Canon, 0x32b4, "Canon EOS 1300D", ptp_flag_lv, 5184, 3456, 4.3, Canon EOS Kiss X80 / Canon EOS Rebel T6,
 Canon, 0x32bb, "Canon EOS M5", ptp_flag_lv, 6000, 4000, 3.71,,
-Canon, 0x32c5, "Canon EOS M6", ptp_flag_lv, 6000, 4000, 3.71,,
 Canon, 0x32c9, "Canon EOS 800D", ptp_flag_lv, 6000, 4000, 3.71, Canon EOS Kiss X9i / Canon EOS Rebel T7i,
 Canon, 0x32ca, "Canon EOS 6D Mark II", ptp_flag_lv, 6240, 4160, 5.7,,
 Canon, 0x32cb, "Canon EOS 77D", ptp_flag_lv, 6000, 4000, 3.71, Canon EOS 9000D / Canon EOS 77D,

--- a/indigo_drivers/ccd_ptp/ptp_camera_model.h
+++ b/indigo_drivers/ccd_ptp/ptp_camera_model.h
@@ -48,7 +48,6 @@ static ptp_camera_model CAMERA[] = {
   { CANON_VID, 0x32af, "Canon EOS 5DSR", ptp_flag_lv, 8688, 5792, 4.14 },
   { CANON_VID, 0x32b4, "Canon EOS 1300D", ptp_flag_lv, 5184, 3456, 4.3 },
   { CANON_VID, 0x32bb, "Canon EOS M5", ptp_flag_lv, 6000, 4000, 3.71 },
-  { CANON_VID, 0x32c5, "Canon EOS M6", ptp_flag_lv, 6000, 4000, 3.71 },
   { CANON_VID, 0x32c9, "Canon EOS 800D", ptp_flag_lv, 6000, 4000, 3.71 },
   { CANON_VID, 0x32ca, "Canon EOS 6D Mark II", ptp_flag_lv, 6240, 4160, 5.7 },
   { CANON_VID, 0x32cb, "Canon EOS 77D", ptp_flag_lv, 6000, 4000, 3.71 },

--- a/indigo_linux_drivers/ccd_gphoto2/dslr_model_info.h
+++ b/indigo_linux_drivers/ccd_gphoto2/dslr_model_info.h
@@ -37,7 +37,6 @@ static struct dslr_model_info {
   { "CANON EOS R3", 6000, 4000, 6.0 },
   { "CANON EOS R", 6720, 4480, 5.35 },
   { "CANON EOS M6 MARK II", 6960, 4640, 3.2 },
-  { "CANON EOS M6", 6000, 4000, 3.71 },
   { "CANON EOS M50 MARK II", 6000, 4000, 3.71 },
   { "CANON EOS M50", 6000, 4000, 3.71 },
   { "CANON EOS M5", 6000, 4000, 3.71 },


### PR DESCRIPTION
When the tried to connect to the EOS M6, it could not be connected.
Apparently, the EOS M6 firmware forces the connection in SD card reader mode when connected via USB.
The manufacturer's own software also does not provide control of the EOS M6.
I therefore propose to remove the EOS M6 from the list.

Reference:
[Canon EOS Utility - table of remote control support models (Japanese)](https://faq.canon.jp/app/answers/detail/a_id/86765)
