### PR TITLE
Ptp with ica transport

### DIFF
--- a/indigo.xcodeproj/project.pbxproj
+++ b/indigo.xcodeproj/project.pbxproj
@@ -317,10 +317,8 @@
 		598A1B7F259BA94A00C0B34C /* indigo_focuser_asi.c in Sources */ = {isa = PBXBuildFile; fileRef = 59A3217021D52C4600EC0F4A /* indigo_focuser_asi.c */; };
 		598A1B80259BA94A00C0B34C /* indigo_agent_guider.c in Sources */ = {isa = PBXBuildFile; fileRef = 5911B6D622633DBE00D6B9EC /* indigo_agent_guider.c */; };
 		598A1B81259BA94A00C0B34C /* indigo_aux_usbdp.c in Sources */ = {isa = PBXBuildFile; fileRef = 5951E148235CDBD900D2DEF1 /* indigo_aux_usbdp.c */; };
-		598A1B82259BA94A00C0B34C /* indigo_ptp.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D586C4422FC6265002D382E /* indigo_ptp.c */; };
 		598A1B83259BA94A00C0B34C /* indigo_bus.c in Sources */ = {isa = PBXBuildFile; fileRef = 59D381A81D9592A400E87393 /* indigo_bus.c */; };
 		598A1B84259BA94A00C0B34C /* indigo_ccd_altair.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BBD17321823693008199D6 /* indigo_ccd_altair.c */; };
-		598A1B85259BA94A00C0B34C /* indigo_ccd_ica.m in Sources */ = {isa = PBXBuildFile; fileRef = 59C499E21EFADFE000E750AA /* indigo_ccd_ica.m */; };
 		598A1B86259BA94A00C0B34C /* indigo_ccd_sbig.c in Sources */ = {isa = PBXBuildFile; fileRef = 59F4EC701E941D1700CC7772 /* indigo_ccd_sbig.c */; };
 		598A1B87259BA94A00C0B34C /* indigo_focuser_mjkzz.c in Sources */ = {isa = PBXBuildFile; fileRef = 592E79162168DD7A00E856F3 /* indigo_focuser_mjkzz.c */; };
 		598A1B88259BA94A00C0B34C /* indigo_focuser_mypro2.c in Sources */ = {isa = PBXBuildFile; fileRef = 5973456B256704CB001741D4 /* indigo_focuser_mypro2.c */; };
@@ -351,7 +349,6 @@
 		598A1BA1259BA94A00C0B34C /* indigo_focuser_nfocus.c in Sources */ = {isa = PBXBuildFile; fileRef = 9DADEE5621511322008C6FBE /* indigo_focuser_nfocus.c */; };
 		598A1BA2259BA94A00C0B34C /* indigo_rotator_driver.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D743A5A23FD57F80093319F /* indigo_rotator_driver.c */; };
 		598A1BA3259BA94A00C0B34C /* libuvc_ctrl.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D73E60D21FF37F7003CEC15 /* libuvc_ctrl.c */; };
-		598A1BA4259BA94A00C0B34C /* indigo_ica_ptp_sony.m in Sources */ = {isa = PBXBuildFile; fileRef = 59CC779C1F27BCF2003AD2DB /* indigo_ica_ptp_sony.m */; };
 		598A1BA5259BA94A00C0B34C /* indigo_aux_upb.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D6940892180B9F600AB112C /* indigo_aux_upb.c */; };
 		598A1BA6259BA94A00C0B34C /* indigo_mount_synscan.c in Sources */ = {isa = PBXBuildFile; fileRef = 9DAD521921246C17002FCC79 /* indigo_mount_synscan.c */; };
 		598A1BA7259BA94A00C0B34C /* NSDictionary+DDHidExtras.m in Sources */ = {isa = PBXBuildFile; fileRef = 595F290C211E211100380EF4 /* NSDictionary+DDHidExtras.m */; };
@@ -380,11 +377,9 @@
 		598A1BBE259BA94A00C0B34C /* indigo_guider_gpusb.c in Sources */ = {isa = PBXBuildFile; fileRef = 59FE346B2187B5FD004FB5D4 /* indigo_guider_gpusb.c */; };
 		598A1BBF259BA94A00C0B34C /* indigo_driver_xml.c in Sources */ = {isa = PBXBuildFile; fileRef = 59D382031D9720C200E87393 /* indigo_driver_xml.c */; };
 		598A1BC0259BA94A00C0B34C /* indigo_agent_scripting.c in Sources */ = {isa = PBXBuildFile; fileRef = 5910D9AD257FFA630015D915 /* indigo_agent_scripting.c */; };
-		598A1BC1259BA94A00C0B34C /* indigo_ica_ptp_canon.m in Sources */ = {isa = PBXBuildFile; fileRef = 59E38B501F1577A000187839 /* indigo_ica_ptp_canon.m */; };
 		598A1BC2259BA94A00C0B34C /* nexstar_pec.c in Sources */ = {isa = PBXBuildFile; fileRef = 598C583321A75B1A001CA8C0 /* nexstar_pec.c */; };
 		598A1BC3259BA94A00C0B34C /* indigo_wheel_driver.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D9EA6B01DBFA30600E11841 /* indigo_wheel_driver.c */; };
 		598A1BC4259BA94A00C0B34C /* indigo_focuser_wemacro_bt.m in Sources */ = {isa = PBXBuildFile; fileRef = 59463C1820DE6781004950F2 /* indigo_focuser_wemacro_bt.m */; };
-		598A1BC5259BA94A00C0B34C /* indigo_ccd_ptp.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D586C3F22FB0D43002D382E /* indigo_ccd_ptp.c */; };
 		598A1BC6259BA94A00C0B34C /* indigo_mount_synscan_guider.c in Sources */ = {isa = PBXBuildFile; fileRef = 59A321B421D691D600EC0F4A /* indigo_mount_synscan_guider.c */; };
 		598A1BC7259BA94A00C0B34C /* indigo_agent_snoop.c in Sources */ = {isa = PBXBuildFile; fileRef = 595AA1CA1FC5ED8A00350E7B /* indigo_agent_snoop.c */; };
 		598A1BC8259BA94A00C0B34C /* indigo_ser.c in Sources */ = {isa = PBXBuildFile; fileRef = 59C3BAFB254DE8AD000720B4 /* indigo_ser.c */; };
@@ -395,7 +390,6 @@
 		598A1BCD259BA94A00C0B34C /* indigo_client_xml.c in Sources */ = {isa = PBXBuildFile; fileRef = 59D382061D97314C00E87393 /* indigo_client_xml.c */; };
 		598A1BCE259BA94A00C0B34C /* indigo_focuser_dmfc.c in Sources */ = {isa = PBXBuildFile; fileRef = 9DFE1865213586AB00149BDE /* indigo_focuser_dmfc.c */; };
 		598A1BCF259BA94A00C0B34C /* indigo_mount_driver.c in Sources */ = {isa = PBXBuildFile; fileRef = 59D707671DC527B800DEF566 /* indigo_mount_driver.c */; };
-		598A1BD0259BA94A00C0B34C /* indigo_ica_ptp.m in Sources */ = {isa = PBXBuildFile; fileRef = 59C499E41EFADFE000E750AA /* indigo_ica_ptp.m */; };
 		598A1BD1259BA94A00C0B34C /* indigo_json.c in Sources */ = {isa = PBXBuildFile; fileRef = 599A63A51DE8BD1700ABC827 /* indigo_json.c */; };
 		598A1BD2259BA94A00C0B34C /* indigo_server_tcp.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D97F8061D9A89ED00582EAF /* indigo_server_tcp.c */; };
 		598A1BD3259BA94A00C0B34C /* indigo_mount_synscan_protocol.c in Sources */ = {isa = PBXBuildFile; fileRef = 9DAD521A21246C17002FCC79 /* indigo_mount_synscan_protocol.c */; };
@@ -414,7 +408,6 @@
 		598A1BE0259BA94A00C0B34C /* indigo_aux_driver.c in Sources */ = {isa = PBXBuildFile; fileRef = 59588CAE211CC30B00E9FC27 /* indigo_aux_driver.c */; };
 		598A1BE1259BA94A00C0B34C /* libuvc_frame_mjpeg.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D73E60E21FF37F8003CEC15 /* libuvc_frame_mjpeg.c */; };
 		598A1BE2259BA94A00C0B34C /* indigo_mount_lx200.c in Sources */ = {isa = PBXBuildFile; fileRef = 9DB918001DF8546800678721 /* indigo_mount_lx200.c */; };
-		598A1BE3259BA94A00C0B34C /* indigo_ica_ptp_nikon.m in Sources */ = {isa = PBXBuildFile; fileRef = 59E38B521F1577A000187839 /* indigo_ica_ptp_nikon.m */; };
 		598A1BE4259BA94A00C0B34C /* indigo_wheel_atik.c in Sources */ = {isa = PBXBuildFile; fileRef = 593CFE411DFC8A12003B63D4 /* indigo_wheel_atik.c */; };
 		598A1BE5259BA94A00C0B34C /* DDHidDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = 595F2913211E211100380EF4 /* DDHidDevice.m */; };
 		598A1BE6259BA94A00C0B34C /* indigo_guider_asi.c in Sources */ = {isa = PBXBuildFile; fileRef = 593AD1011EF8399500C059BC /* indigo_guider_asi.c */; };
@@ -467,7 +460,6 @@
 		598A1C24259BA94A00C0B34C /* indigo_focuser_driver.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DAC59D21DC0A8AD00AE410D /* indigo_focuser_driver.h */; };
 		598A1C25259BA94A00C0B34C /* indigo_rotator_driver.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D743A5C23FD58070093319F /* indigo_rotator_driver.h */; };
 		598A1C26259BA94A00C0B34C /* indigo_focuser_wemacro_bt.h in Headers */ = {isa = PBXBuildFile; fileRef = 59463C1520DE6781004950F2 /* indigo_focuser_wemacro_bt.h */; };
-		598A1C27259BA94A00C0B34C /* indigo_ica_ptp.h in Headers */ = {isa = PBXBuildFile; fileRef = 59C499E31EFADFE000E750AA /* indigo_ica_ptp.h */; };
 		598A1C28259BA94A00C0B34C /* indigo_usb_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 59B636AD20A74CD400EF2D52 /* indigo_usb_utils.h */; };
 		598A1C2A259BA94A00C0B34C /* indigo_agent_snoop.h in Headers */ = {isa = PBXBuildFile; fileRef = 595AA1CC1FC5ED8A00350E7B /* indigo_agent_snoop.h */; };
 		598A1C2B259BA94A00C0B34C /* indigo_agent_auxiliary.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DC4967D22BA7B810052AB3E /* indigo_agent_auxiliary.h */; };
@@ -488,7 +480,6 @@
 		598A1C3A259BA94A00C0B34C /* indigo_wheel_qhy.h in Headers */ = {isa = PBXBuildFile; fileRef = 5979C882254A9EED005395BE /* indigo_wheel_qhy.h */; };
 		598A1C3B259BA94A00C0B34C /* indigo_guider_eqmac.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D4D64AE20A9D946008ECE4B /* indigo_guider_eqmac.h */; };
 		598A1C3C259BA94A00C0B34C /* DDHidElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 595F28FF211E211100380EF4 /* DDHidElement.h */; };
-		598A1C3D259BA94A00C0B34C /* indigo_ccd_ica.h in Headers */ = {isa = PBXBuildFile; fileRef = 59C499E11EFADFE000E750AA /* indigo_ccd_ica.h */; };
 		598A1C3E259BA94A00C0B34C /* DDHidDevice.h in Headers */ = {isa = PBXBuildFile; fileRef = 595F2907211E211100380EF4 /* DDHidDevice.h */; };
 		598A1C3F259BA94A00C0B34C /* indigo_mount_synscan_driver.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DAD521B21246C17002FCC79 /* indigo_mount_synscan_driver.h */; };
 		598A1C40259BA94A00C0B34C /* indigo_agent_imager.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DA451CD21908CBC00818B58 /* indigo_agent_imager.h */; };
@@ -505,7 +496,6 @@
 		598A1C4B259BA94A00C0B34C /* indigo_json.h in Headers */ = {isa = PBXBuildFile; fileRef = 599A63A61DE8BD1700ABC827 /* indigo_json.h */; };
 		598A1C4C259BA94A00C0B34C /* indigo_ptp_sony.h in Headers */ = {isa = PBXBuildFile; fileRef = 59D6719122FDBB8D00D08A2A /* indigo_ptp_sony.h */; };
 		598A1C4D259BA94A00C0B34C /* indigo_ptp_fuji.h in Headers */ = {isa = PBXBuildFile; fileRef = 59C3BB10255077E8000720B4 /* indigo_ptp_fuji.h */; };
-		598A1C4E259BA94A00C0B34C /* indigo_ica_ptp_nikon.h in Headers */ = {isa = PBXBuildFile; fileRef = 59E38B511F1577A000187839 /* indigo_ica_ptp_nikon.h */; };
 		598A1C4F259BA94A00C0B34C /* indigo_aux_sqm.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DC4969722C39A170052AB3E /* indigo_aux_sqm.h */; };
 		598A1C50259BA94A00C0B34C /* indigo_focuser_steeldrive2.h in Headers */ = {isa = PBXBuildFile; fileRef = 59A242E922A5B45E001C38F8 /* indigo_focuser_steeldrive2.h */; };
 		598A1C51259BA94A00C0B34C /* indigo_agent.h in Headers */ = {isa = PBXBuildFile; fileRef = 595AA1CF1FC5EEFE00350E7B /* indigo_agent.h */; };
@@ -554,7 +544,6 @@
 		598A1C7C259BA94A00C0B34C /* indigo_agent_guider.h in Headers */ = {isa = PBXBuildFile; fileRef = 5911B6D822633DBE00D6B9EC /* indigo_agent_guider.h */; };
 		598A1C7D259BA94A00C0B34C /* DDHidQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 595F2903211E211100380EF4 /* DDHidQueue.h */; };
 		598A1C7E259BA94A00C0B34C /* NSDictionary+DDHidExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = 595F28FC211E211100380EF4 /* NSDictionary+DDHidExtras.h */; };
-		598A1C7F259BA94A00C0B34C /* indigo_ica_ptp_canon.h in Headers */ = {isa = PBXBuildFile; fileRef = 59E38B4F1F1577A000187839 /* indigo_ica_ptp_canon.h */; };
 		598A1C80259BA94A00C0B34C /* gxccd.h in Headers */ = {isa = PBXBuildFile; fileRef = 59A52D5721A3360B000B6F27 /* gxccd.h */; };
 		598A1C81259BA94A00C0B34C /* indigo_mount_driver.h in Headers */ = {isa = PBXBuildFile; fileRef = 59D707681DC527B800DEF566 /* indigo_mount_driver.h */; };
 		598A1C82259BA94A00C0B34C /* indigo_wheel_quantum.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DAD52432126BD98002FCC79 /* indigo_wheel_quantum.h */; };
@@ -713,10 +702,6 @@
 		59C3BAFD254DE8AD000720B4 /* indigo_ser.c in Sources */ = {isa = PBXBuildFile; fileRef = 59C3BAFB254DE8AD000720B4 /* indigo_ser.c */; };
 		59C3BB12255077E9000720B4 /* indigo_ptp_fuji.c in Sources */ = {isa = PBXBuildFile; fileRef = 59C3BB0F255077E8000720B4 /* indigo_ptp_fuji.c */; };
 		59C3BB13255077E9000720B4 /* indigo_ptp_fuji.h in Headers */ = {isa = PBXBuildFile; fileRef = 59C3BB10255077E8000720B4 /* indigo_ptp_fuji.h */; };
-		59C499E51EFADFE000E750AA /* indigo_ccd_ica.h in Headers */ = {isa = PBXBuildFile; fileRef = 59C499E11EFADFE000E750AA /* indigo_ccd_ica.h */; };
-		59C499E61EFADFE000E750AA /* indigo_ccd_ica.m in Sources */ = {isa = PBXBuildFile; fileRef = 59C499E21EFADFE000E750AA /* indigo_ccd_ica.m */; };
-		59C499E71EFADFE000E750AA /* indigo_ica_ptp.h in Headers */ = {isa = PBXBuildFile; fileRef = 59C499E31EFADFE000E750AA /* indigo_ica_ptp.h */; };
-		59C499E81EFADFE000E750AA /* indigo_ica_ptp.m in Sources */ = {isa = PBXBuildFile; fileRef = 59C499E41EFADFE000E750AA /* indigo_ica_ptp.m */; };
 		59C4C88420CEF107007EE330 /* indigo_focuser_wemacro.h in Headers */ = {isa = PBXBuildFile; fileRef = 59C4C88020CEF107007EE330 /* indigo_focuser_wemacro.h */; };
 		59C565072464A14C00344C0C /* indigo_aux_mgbox.c in Sources */ = {isa = PBXBuildFile; fileRef = 59C565012464A13A00344C0C /* indigo_aux_mgbox.c */; };
 		59C76F0C237872480091B966 /* nexstar.h in Headers */ = {isa = PBXBuildFile; fileRef = 598C583721A75B1A001CA8C0 /* nexstar.h */; };
@@ -734,7 +719,6 @@
 		59C8E7FB1DBBDF7A00AA3F0A /* indigo_wheel_sx.c in Sources */ = {isa = PBXBuildFile; fileRef = 59C8E7F91DBBDF7400AA3F0A /* indigo_wheel_sx.c */; };
 		59CBD47F1FAF6C93000DAFDB /* indigo_gps_simulator.c in Sources */ = {isa = PBXBuildFile; fileRef = 59CBD47B1FAF6C80000DAFDB /* indigo_gps_simulator.c */; };
 		59CBD4801FAF6C99000DAFDB /* indigo_gps_driver.c in Sources */ = {isa = PBXBuildFile; fileRef = 59CBD4781FAF6C19000DAFDB /* indigo_gps_driver.c */; };
-		59CC779D1F27BD07003AD2DB /* indigo_ica_ptp_sony.m in Sources */ = {isa = PBXBuildFile; fileRef = 59CC779C1F27BCF2003AD2DB /* indigo_ica_ptp_sony.m */; };
 		59D138A2283E5A8700FCC514 /* libraw.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 59D138A1283E5A6C00FCC514 /* libraw.a */; };
 		59D138A3283E5A9C00FCC514 /* libraw.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 59D138A1283E5A6C00FCC514 /* libraw.a */; };
 		59D138A5283E6BAA00FCC514 /* indigo_dslr_raw.c in Sources */ = {isa = PBXBuildFile; fileRef = 59D138A4283E6BAA00FCC514 /* indigo_dslr_raw.c */; };
@@ -772,10 +756,6 @@
 		59DD69CF1FC1D30300AEF0DF /* indigo_dome_driver.h in Headers */ = {isa = PBXBuildFile; fileRef = 59DD69CD1FC1D30300AEF0DF /* indigo_dome_driver.h */; };
 		59DD69D61FC1DC4900AEF0DF /* indigo_dome_simulator.h in Headers */ = {isa = PBXBuildFile; fileRef = 59DD69D21FC1DC4900AEF0DF /* indigo_dome_simulator.h */; };
 		59DD69D71FC1DC4900AEF0DF /* indigo_dome_simulator.c in Sources */ = {isa = PBXBuildFile; fileRef = 59DD69D41FC1DC4900AEF0DF /* indigo_dome_simulator.c */; };
-		59E38B531F1577A000187839 /* indigo_ica_ptp_canon.h in Headers */ = {isa = PBXBuildFile; fileRef = 59E38B4F1F1577A000187839 /* indigo_ica_ptp_canon.h */; };
-		59E38B541F1577A000187839 /* indigo_ica_ptp_canon.m in Sources */ = {isa = PBXBuildFile; fileRef = 59E38B501F1577A000187839 /* indigo_ica_ptp_canon.m */; };
-		59E38B551F1577A000187839 /* indigo_ica_ptp_nikon.h in Headers */ = {isa = PBXBuildFile; fileRef = 59E38B511F1577A000187839 /* indigo_ica_ptp_nikon.h */; };
-		59E38B561F1577A000187839 /* indigo_ica_ptp_nikon.m in Sources */ = {isa = PBXBuildFile; fileRef = 59E38B521F1577A000187839 /* indigo_ica_ptp_nikon.m */; };
 		59E5A2A323C125A300E8BBBF /* indigo_mount_rainbow.c in Sources */ = {isa = PBXBuildFile; fileRef = 59E5A29823C1238400E8BBBF /* indigo_mount_rainbow.c */; };
 		59E6B7FA27E3835E007A2A7B /* indigo_ccd_mi.c in Sources */ = {isa = PBXBuildFile; fileRef = 59FC2EB6210CA76100730343 /* indigo_ccd_mi.c */; };
 		59E6B7FB27E383B9007A2A7B /* libgxccd.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 59A52D5B21A3360B000B6F27 /* libgxccd.a */; };
@@ -818,8 +798,6 @@
 		9D4D64B320A9D947008ECE4B /* indigo_guider_eqmac.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D4D64B020A9D946008ECE4B /* indigo_guider_eqmac.c */; };
 		9D4F4742215A4447006110FD /* indigo_focuser_moonlite.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D4F4741215A4440006110FD /* indigo_focuser_moonlite.c */; };
 		9D586C4022FB0D43002D382E /* indigo_ccd_ptp.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D586C3E22FB0D43002D382E /* indigo_ccd_ptp.h */; };
-		9D586C4122FB0D43002D382E /* indigo_ccd_ptp.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D586C3F22FB0D43002D382E /* indigo_ccd_ptp.c */; };
-		9D586C4522FC6265002D382E /* indigo_ptp.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D586C4422FC6265002D382E /* indigo_ptp.c */; };
 		9D59D66F20D3F82A009EA8FF /* indigo_ccd_apogee.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9D59D5E020D3F829009EA8FF /* indigo_ccd_apogee.cpp */; };
 		9D59D67020D3F82A009EA8FF /* indigo_ccd_apogee.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D59D5E120D3F829009EA8FF /* indigo_ccd_apogee.h */; };
 		9D61B9DF216DE636000DE7E8 /* indigo_focuser_mjkzz_bt.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D61B9DB216DE62B000DE7E8 /* indigo_focuser_mjkzz_bt.m */; };
@@ -861,6 +839,30 @@
 		9D9EA6B71DBFA30600E11841 /* indigo_wheel_driver.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D9EA6B11DBFA30600E11841 /* indigo_wheel_driver.h */; };
 		9DA451CE21908CBC00818B58 /* indigo_agent_imager.c in Sources */ = {isa = PBXBuildFile; fileRef = 9DA451CC21908CBC00818B58 /* indigo_agent_imager.c */; };
 		9DA451CF21908CBC00818B58 /* indigo_agent_imager.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DA451CD21908CBC00818B58 /* indigo_agent_imager.h */; };
+		9DA71CF12A0255A900CFA533 /* indigo_ccd_ptp.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DA71CF02A0255A900CFA533 /* indigo_ccd_ptp.m */; };
+		9DA71CF22A0255A900CFA533 /* indigo_ccd_ptp.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DA71CF02A0255A900CFA533 /* indigo_ccd_ptp.m */; };
+		9DA71CF32A025A0A00CFA533 /* indigo_ptp.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D586C4422FC6265002D382E /* indigo_ptp.c */; };
+		9DA71CF42A025A0B00CFA533 /* indigo_ptp.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D586C4422FC6265002D382E /* indigo_ptp.c */; };
+		9DA71D012A029BE500CFA533 /* indigo_ccd_ica.m in Sources */ = {isa = PBXBuildFile; fileRef = 59C499E21EFADFE000E750AA /* indigo_ccd_ica.m */; };
+		9DA71D022A029BE500CFA533 /* indigo_ica_ptp.m in Sources */ = {isa = PBXBuildFile; fileRef = 59C499E41EFADFE000E750AA /* indigo_ica_ptp.m */; };
+		9DA71D032A029BE500CFA533 /* indigo_ica_ptp_canon.h in Headers */ = {isa = PBXBuildFile; fileRef = 59E38B4F1F1577A000187839 /* indigo_ica_ptp_canon.h */; };
+		9DA71D042A029BE500CFA533 /* indigo_ica_ptp_sony.h in Headers */ = {isa = PBXBuildFile; fileRef = 59CC779B1F27BCF2003AD2DB /* indigo_ica_ptp_sony.h */; };
+		9DA71D052A029BE500CFA533 /* indigo_ica_ptp_nikon.h in Headers */ = {isa = PBXBuildFile; fileRef = 59E38B511F1577A000187839 /* indigo_ica_ptp_nikon.h */; };
+		9DA71D062A029BE500CFA533 /* indigo_ica_ptp.h in Headers */ = {isa = PBXBuildFile; fileRef = 59C499E31EFADFE000E750AA /* indigo_ica_ptp.h */; };
+		9DA71D072A029BE500CFA533 /* indigo_ica_ptp_canon.m in Sources */ = {isa = PBXBuildFile; fileRef = 59E38B501F1577A000187839 /* indigo_ica_ptp_canon.m */; };
+		9DA71D082A029BE500CFA533 /* indigo_ccd_ica.h in Headers */ = {isa = PBXBuildFile; fileRef = 59C499E11EFADFE000E750AA /* indigo_ccd_ica.h */; };
+		9DA71D092A029BE500CFA533 /* indigo_ica_ptp_nikon.m in Sources */ = {isa = PBXBuildFile; fileRef = 59E38B521F1577A000187839 /* indigo_ica_ptp_nikon.m */; };
+		9DA71D0A2A029BE500CFA533 /* indigo_ica_ptp_sony.m in Sources */ = {isa = PBXBuildFile; fileRef = 59CC779C1F27BCF2003AD2DB /* indigo_ica_ptp_sony.m */; };
+		9DA71D0B2A029BE600CFA533 /* indigo_ccd_ica.m in Sources */ = {isa = PBXBuildFile; fileRef = 59C499E21EFADFE000E750AA /* indigo_ccd_ica.m */; };
+		9DA71D0C2A029BE600CFA533 /* indigo_ica_ptp.m in Sources */ = {isa = PBXBuildFile; fileRef = 59C499E41EFADFE000E750AA /* indigo_ica_ptp.m */; };
+		9DA71D0D2A029BE600CFA533 /* indigo_ica_ptp_canon.h in Headers */ = {isa = PBXBuildFile; fileRef = 59E38B4F1F1577A000187839 /* indigo_ica_ptp_canon.h */; };
+		9DA71D0E2A029BE600CFA533 /* indigo_ica_ptp_sony.h in Headers */ = {isa = PBXBuildFile; fileRef = 59CC779B1F27BCF2003AD2DB /* indigo_ica_ptp_sony.h */; };
+		9DA71D0F2A029BE600CFA533 /* indigo_ica_ptp_nikon.h in Headers */ = {isa = PBXBuildFile; fileRef = 59E38B511F1577A000187839 /* indigo_ica_ptp_nikon.h */; };
+		9DA71D102A029BE600CFA533 /* indigo_ica_ptp.h in Headers */ = {isa = PBXBuildFile; fileRef = 59C499E31EFADFE000E750AA /* indigo_ica_ptp.h */; };
+		9DA71D112A029BE600CFA533 /* indigo_ica_ptp_canon.m in Sources */ = {isa = PBXBuildFile; fileRef = 59E38B501F1577A000187839 /* indigo_ica_ptp_canon.m */; };
+		9DA71D122A029BE600CFA533 /* indigo_ccd_ica.h in Headers */ = {isa = PBXBuildFile; fileRef = 59C499E11EFADFE000E750AA /* indigo_ccd_ica.h */; };
+		9DA71D132A029BE600CFA533 /* indigo_ica_ptp_nikon.m in Sources */ = {isa = PBXBuildFile; fileRef = 59E38B521F1577A000187839 /* indigo_ica_ptp_nikon.m */; };
+		9DA71D142A029BE600CFA533 /* indigo_ica_ptp_sony.m in Sources */ = {isa = PBXBuildFile; fileRef = 59CC779C1F27BCF2003AD2DB /* indigo_ica_ptp_sony.m */; };
 		9DAC59D31DC0A8AD00AE410D /* indigo_focuser_driver.c in Sources */ = {isa = PBXBuildFile; fileRef = 9DAC59D11DC0A8AD00AE410D /* indigo_focuser_driver.c */; };
 		9DAC59D41DC0A8AD00AE410D /* indigo_focuser_driver.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DAC59D21DC0A8AD00AE410D /* indigo_focuser_driver.h */; };
 		9DAC59D91DC24E1400AE410D /* indigo_focuser_fcusb.c in Sources */ = {isa = PBXBuildFile; fileRef = 9DAC59D61DC24E1400AE410D /* indigo_focuser_fcusb.c */; };
@@ -4631,6 +4633,7 @@
 		9DA451CB21908CBC00818B58 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		9DA451CC21908CBC00818B58 /* indigo_agent_imager.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = indigo_agent_imager.c; sourceTree = "<group>"; wrapsLines = 0; };
 		9DA451CD21908CBC00818B58 /* indigo_agent_imager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = indigo_agent_imager.h; sourceTree = "<group>"; };
+		9DA71CF02A0255A900CFA533 /* indigo_ccd_ptp.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = indigo_ccd_ptp.m; sourceTree = "<group>"; };
 		9DAC59D11DC0A8AD00AE410D /* indigo_focuser_driver.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = indigo_focuser_driver.c; sourceTree = "<group>"; };
 		9DAC59D21DC0A8AD00AE410D /* indigo_focuser_driver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = indigo_focuser_driver.h; sourceTree = "<group>"; };
 		9DAC59D51DC24E1400AE410D /* indigo_focuser_fcusb_main.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = indigo_focuser_fcusb_main.c; sourceTree = "<group>"; };
@@ -12834,6 +12837,7 @@
 				9D586C3D22FB0C34002D382E /* README.md */,
 				9D586C3E22FB0D43002D382E /* indigo_ccd_ptp.h */,
 				9D586C3F22FB0D43002D382E /* indigo_ccd_ptp.c */,
+				9DA71CF02A0255A900CFA533 /* indigo_ccd_ptp.m */,
 				59FA0B1C22FB400900A15D19 /* indigo_ptp.h */,
 				9D586C4422FC6265002D382E /* indigo_ptp.c */,
 				59FA0B1D22FCACC600A15D19 /* indigo_ptp_canon.h */,
@@ -13705,6 +13709,7 @@
 				598A1C20259BA94A00C0B34C /* nexstar.h in Headers */,
 				5995A8D025A9ABEC003987F1 /* indigo_platesolver.h in Headers */,
 				598A1C21259BA94A00C0B34C /* indigo_ccd_iidc.h in Headers */,
+				9DA71D0F2A029BE600CFA533 /* indigo_ica_ptp_nikon.h in Headers */,
 				598A1C22259BA94A00C0B34C /* sbigudrv.h in Headers */,
 				59111D0E285F53D100E57194 /* indigocat_dynamical_time.h in Headers */,
 				59111D0D285F53D100E57194 /* indigocat_nutation.h in Headers */,
@@ -13713,7 +13718,6 @@
 				598A1C24259BA94A00C0B34C /* indigo_focuser_driver.h in Headers */,
 				598A1C25259BA94A00C0B34C /* indigo_rotator_driver.h in Headers */,
 				598A1C26259BA94A00C0B34C /* indigo_focuser_wemacro_bt.h in Headers */,
-				598A1C27259BA94A00C0B34C /* indigo_ica_ptp.h in Headers */,
 				59A68E1D277DC3D0000439CC /* indigo_ccd_svb.h in Headers */,
 				598A1C28259BA94A00C0B34C /* indigo_usb_utils.h in Headers */,
 				598A1C2A259BA94A00C0B34C /* indigo_agent_snoop.h in Headers */,
@@ -13726,6 +13730,7 @@
 				598A1C30259BA94A00C0B34C /* indigo_mount_simulator.h in Headers */,
 				598A1C31259BA94A00C0B34C /* libatik.h in Headers */,
 				598A1C32259BA94A00C0B34C /* qhyccdcamdef.h in Headers */,
+				9DA71D122A029BE600CFA533 /* indigo_ccd_ica.h in Headers */,
 				598A1C33259BA94A00C0B34C /* indigo_wheel_optec.h in Headers */,
 				59FFB06A288D3D6600F172AC /* PlayerOneCamera.h in Headers */,
 				598A1C34259BA94A00C0B34C /* qhyccderr.h in Headers */,
@@ -13740,13 +13745,14 @@
 				598A1C3B259BA94A00C0B34C /* indigo_guider_eqmac.h in Headers */,
 				59111D09285F511500E57194 /* indigocat_ss.h in Headers */,
 				593A8F0E285F615400F6CF1C /* indigocat_precession.h in Headers */,
+				9DA71D0E2A029BE600CFA533 /* indigo_ica_ptp_sony.h in Headers */,
 				598A1C3C259BA94A00C0B34C /* DDHidElement.h in Headers */,
-				598A1C3D259BA94A00C0B34C /* indigo_ccd_ica.h in Headers */,
 				598A1C3E259BA94A00C0B34C /* DDHidDevice.h in Headers */,
 				598A1C3F259BA94A00C0B34C /* indigo_mount_synscan_driver.h in Headers */,
 				598A1C40259BA94A00C0B34C /* indigo_agent_imager.h in Headers */,
 				598A1C41259BA94A00C0B34C /* libfli.h in Headers */,
 				598A1C42259BA94A00C0B34C /* indigo_io.h in Headers */,
+				9DA71D0D2A029BE600CFA533 /* indigo_ica_ptp_canon.h in Headers */,
 				598A1C43259BA94A00C0B34C /* indigo_dome_simulator.h in Headers */,
 				598A1C44259BA94A00C0B34C /* nex_open.h in Headers */,
 				59D2B9FB294A332E002F0F90 /* indigo_mount_asi.h in Headers */,
@@ -13764,7 +13770,6 @@
 				598A1C4C259BA94A00C0B34C /* indigo_ptp_sony.h in Headers */,
 				59790B2E29B2796300F73B1D /* indigo_service_discovery.h in Headers */,
 				598A1C4D259BA94A00C0B34C /* indigo_ptp_fuji.h in Headers */,
-				598A1C4E259BA94A00C0B34C /* indigo_ica_ptp_nikon.h in Headers */,
 				598A1C4F259BA94A00C0B34C /* indigo_aux_sqm.h in Headers */,
 				59D29A182841469D00D5E7F7 /* indigo_mount_starbook.h in Headers */,
 				598A1C50259BA94A00C0B34C /* indigo_focuser_steeldrive2.h in Headers */,
@@ -13824,7 +13829,6 @@
 				598A1C7D259BA94A00C0B34C /* DDHidQueue.h in Headers */,
 				598A1C7E259BA94A00C0B34C /* NSDictionary+DDHidExtras.h in Headers */,
 				59118C322996EB440004BEC8 /* indigo_ccd_ogma.h in Headers */,
-				598A1C7F259BA94A00C0B34C /* indigo_ica_ptp_canon.h in Headers */,
 				59111D0F285F53D100E57194 /* indigocat_solar_system.h in Headers */,
 				598A1C80259BA94A00C0B34C /* gxccd.h in Headers */,
 				598A1C81259BA94A00C0B34C /* indigo_mount_driver.h in Headers */,
@@ -13855,6 +13859,7 @@
 				59111D11285F53D100E57194 /* indigocat_vsop87.h in Headers */,
 				598A1C95259BA94A00C0B34C /* indigo_ptp_canon.h in Headers */,
 				598A1C96259BA94A00C0B34C /* DDHidAppleMikey.h in Headers */,
+				9DA71D102A029BE600CFA533 /* indigo_ica_ptp.h in Headers */,
 				598A1C97259BA94A00C0B34C /* indigo_filter.h in Headers */,
 				598A1C98259BA94A00C0B34C /* config.h in Headers */,
 			);
@@ -13865,6 +13870,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				59D9684221A2FFC40069A64C /* libdsusb.h in Headers */,
+				9DA71D062A029BE500CFA533 /* indigo_ica_ptp.h in Headers */,
 				5910D9C62580284E0015D915 /* duk_config.h in Headers */,
 				595F291E211E211100380EF4 /* DDHidUsageTables.h in Headers */,
 				599A63B11DEA2F4700ABC827 /* indigo_driver_json.h in Headers */,
@@ -13882,7 +13888,6 @@
 				9D743A5D23FD58080093319F /* indigo_rotator_driver.h in Headers */,
 				59FFB069288D3D6500F172AC /* PlayerOneCamera.h in Headers */,
 				59463C1920DE6781004950F2 /* indigo_focuser_wemacro_bt.h in Headers */,
-				59C499E71EFADFE000E750AA /* indigo_ica_ptp.h in Headers */,
 				59B636AF20A74CD400EF2D52 /* indigo_usb_utils.h in Headers */,
 				595AA1CE1FC5ED8A00350E7B /* indigo_agent_snoop.h in Headers */,
 				9DC4968822BA7B810052AB3E /* indigo_agent_auxiliary.h in Headers */,
@@ -13893,12 +13898,14 @@
 				59111D05285F50A800E57194 /* indigocat_dso.h in Headers */,
 				59958E0125CB0DEB00BEFA1B /* indigo_dome_skyroof.h in Headers */,
 				59A413322971E54C00F0A80B /* PlayerOnePW.h in Headers */,
+				9DA71D082A029BE500CFA533 /* indigo_ccd_ica.h in Headers */,
 				9D73E60521FF36C4003CEC15 /* indigo_ccd_uvc.h in Headers */,
 				59D707711DC52C3E00DEF566 /* indigo_mount_simulator.h in Headers */,
 				59A5302221A35167000B6F27 /* libatik.h in Headers */,
 				595567C824B882DD00DF303D /* qhyccdcamdef.h in Headers */,
 				590DD87F2127590600F2B978 /* indigo_wheel_optec.h in Headers */,
 				595567C524B882DD00DF303D /* qhyccderr.h in Headers */,
+				9DA71D042A029BE500CFA533 /* indigo_ica_ptp_sony.h in Headers */,
 				59588CB1211CC30C00E9FC27 /* indigo_aux_driver.h in Headers */,
 				595F292A211E211200380EF4 /* DDHidJoystick.h in Headers */,
 				9D73E60C21FF37DB003CEC15 /* libuvc_config.h in Headers */,
@@ -13909,7 +13916,6 @@
 				591CD0CC298042C0003243AE /* starshootg.h in Headers */,
 				9D4D64B220A9D947008ECE4B /* indigo_guider_eqmac.h in Headers */,
 				595F291C211E211100380EF4 /* DDHidElement.h in Headers */,
-				59C499E51EFADFE000E750AA /* indigo_ccd_ica.h in Headers */,
 				595F2924211E211200380EF4 /* DDHidDevice.h in Headers */,
 				9DAD522421246C18002FCC79 /* indigo_mount_synscan_driver.h in Headers */,
 				9DA451CF21908CBC00818B58 /* indigo_agent_imager.h in Headers */,
@@ -13930,7 +13936,6 @@
 				59118C312996EB440004BEC8 /* indigo_ccd_ogma.h in Headers */,
 				59111D08285F511500E57194 /* indigocat_ss.h in Headers */,
 				59C3BB13255077E9000720B4 /* indigo_ptp_fuji.h in Headers */,
-				59E38B551F1577A000187839 /* indigo_ica_ptp_nikon.h in Headers */,
 				591CD11429806D46003243AE /* mallincam.h in Headers */,
 				9DC496A322C39A170052AB3E /* indigo_aux_sqm.h in Headers */,
 				59A242F422A5B45F001C38F8 /* indigo_focuser_steeldrive2.h in Headers */,
@@ -13998,15 +14003,16 @@
 				5911B6DA22633DBE00D6B9EC /* indigo_agent_guider.h in Headers */,
 				595F2920211E211100380EF4 /* DDHidQueue.h in Headers */,
 				595F2919211E211100380EF4 /* NSDictionary+DDHidExtras.h in Headers */,
-				59E38B531F1577A000187839 /* indigo_ica_ptp_canon.h in Headers */,
 				59A52D6521A33617000B6F27 /* gxccd.h in Headers */,
 				59D7076A1DC527B800DEF566 /* indigo_mount_driver.h in Headers */,
 				9DAD52472126BD99002FCC79 /* indigo_wheel_quantum.h in Headers */,
+				9DA71D052A029BE500CFA533 /* indigo_ica_ptp_nikon.h in Headers */,
 				9D59D67020D3F82A009EA8FF /* indigo_ccd_apogee.h in Headers */,
 				595F292C211E211200380EF4 /* DDHidAppleRemote.h in Headers */,
 				5955CB6C2684BC9C00685071 /* indigo_dome_beaver.h in Headers */,
 				9DB918041DF8546800678721 /* indigo_mount_lx200.h in Headers */,
 				59413562232404D100ED5FF4 /* indigo_focuser_efa.h in Headers */,
+				9DA71D032A029BE500CFA533 /* indigo_ica_ptp_canon.h in Headers */,
 				593A8F0D285F615400F6CF1C /* indigocat_precession.h in Headers */,
 				591CD0C8298041F1003243AE /* indigo_ccd_ssg.h in Headers */,
 				591CD0EA29805CBE003243AE /* nncam.h in Headers */,
@@ -14340,6 +14346,8 @@
 				598A1B66259BA94A00C0B34C /* indigo_ptp_sony.c in Sources */,
 				598A1B67259BA94A00C0B34C /* libuvc_stream.c in Sources */,
 				59A413392971E54C00F0A80B /* Makefile.inc in Sources */,
+				9DA71D0C2A029BE600CFA533 /* indigo_ica_ptp.m in Sources */,
+				9DA71D142A029BE600CFA533 /* indigo_ica_ptp_sony.m in Sources */,
 				598A1B68259BA94A00C0B34C /* indigo_mount_ioptron.c in Sources */,
 				598A1B69259BA94A00C0B34C /* indigo_gps_nmea.c in Sources */,
 				593A8F11285F616F00F6CF1C /* indigocat_precession.c in Sources */,
@@ -14373,10 +14381,8 @@
 				597BD16426013CDD00239274 /* indigo_agent_alpaca.c in Sources */,
 				598A1B80259BA94A00C0B34C /* indigo_agent_guider.c in Sources */,
 				598A1B81259BA94A00C0B34C /* indigo_aux_usbdp.c in Sources */,
-				598A1B82259BA94A00C0B34C /* indigo_ptp.c in Sources */,
 				598A1B83259BA94A00C0B34C /* indigo_bus.c in Sources */,
 				598A1B84259BA94A00C0B34C /* indigo_ccd_altair.c in Sources */,
-				598A1B85259BA94A00C0B34C /* indigo_ccd_ica.m in Sources */,
 				598A1B86259BA94A00C0B34C /* indigo_ccd_sbig.c in Sources */,
 				598A1B87259BA94A00C0B34C /* indigo_focuser_mjkzz.c in Sources */,
 				598A1B88259BA94A00C0B34C /* indigo_focuser_mypro2.c in Sources */,
@@ -14392,8 +14398,10 @@
 				598A1B90259BA94A00C0B34C /* NSXReturnThrowError.m in Sources */,
 				598A1B91259BA94A00C0B34C /* indigo_mount_synscan_mount.c in Sources */,
 				598A1B92259BA94A00C0B34C /* indigo_rotator_lunatico.c in Sources */,
+				9DA71CF22A0255A900CFA533 /* indigo_ccd_ptp.m in Sources */,
 				598A1B93259BA94A00C0B34C /* indigo_ao_driver.c in Sources */,
 				597DFE252804A880009E37CB /* indigo_rotator_optec.c in Sources */,
+				9DA71D132A029BE600CFA533 /* indigo_ica_ptp_nikon.m in Sources */,
 				598A1B94259BA94A00C0B34C /* indigo_wheel_asi.c in Sources */,
 				598A1B95259BA94A00C0B34C /* indigo_wheel_qhy.c in Sources */,
 				598A1B96259BA94A00C0B34C /* indigo_client.c in Sources */,
@@ -14406,6 +14414,7 @@
 				598A1B9B259BA94A00C0B34C /* indigo_agent_lx200_server.c in Sources */,
 				598A1B9C259BA94A00C0B34C /* libdsi.c in Sources */,
 				598A1B9D259BA94A00C0B34C /* nexstar.c in Sources */,
+				9DA71D0B2A029BE600CFA533 /* indigo_ccd_ica.m in Sources */,
 				598A1B9E259BA94A00C0B34C /* DDHidAppleMikey.m in Sources */,
 				591CCFAD2980396B003243AE /* indigo_ccd_omegonpro.c in Sources */,
 				59F50A3325A5DEDD00C19115 /* indigo_agent_astrometry.c in Sources */,
@@ -14417,7 +14426,6 @@
 				598A1BA2259BA94A00C0B34C /* indigo_rotator_driver.c in Sources */,
 				59F871BD26A87162007DF91C /* indigo_ccd_mi.c in Sources */,
 				598A1BA3259BA94A00C0B34C /* libuvc_ctrl.c in Sources */,
-				598A1BA4259BA94A00C0B34C /* indigo_ica_ptp_sony.m in Sources */,
 				59111CE6285F504200E57194 /* indigocat_mercury.c in Sources */,
 				59111CE7285F504200E57194 /* indigocat_moon.c in Sources */,
 				598A1BA5259BA94A00C0B34C /* indigo_aux_upb.c in Sources */,
@@ -14435,6 +14443,7 @@
 				598A1BAE259BA94A00C0B34C /* indigo_aux_arteskyflat.c in Sources */,
 				598A1BAF259BA94A00C0B34C /* indigo_focuser_mjkzz_bt.m in Sources */,
 				598A1BB0259BA94A00C0B34C /* indigo_filter.c in Sources */,
+				9DA71D112A029BE600CFA533 /* indigo_ica_ptp_canon.m in Sources */,
 				598A1BB1259BA94A00C0B34C /* indigo_ccd_driver.c in Sources */,
 				598A1BB2259BA94A00C0B34C /* indigo_xml.c in Sources */,
 				59FFB068288D3D5C00F172AC /* indigo_ccd_playerone.c in Sources */,
@@ -14459,7 +14468,6 @@
 				598A1BBF259BA94A00C0B34C /* indigo_driver_xml.c in Sources */,
 				59111CE9285F504200E57194 /* indigocat_pluto.c in Sources */,
 				598A1BC0259BA94A00C0B34C /* indigo_agent_scripting.c in Sources */,
-				598A1BC1259BA94A00C0B34C /* indigo_ica_ptp_canon.m in Sources */,
 				598A1BC2259BA94A00C0B34C /* nexstar_pec.c in Sources */,
 				59111CF0285F504200E57194 /* indigocat_nutation.c in Sources */,
 				59111CE8285F504200E57194 /* indigocat_neptune.c in Sources */,
@@ -14467,7 +14475,6 @@
 				598A1BC4259BA94A00C0B34C /* indigo_focuser_wemacro_bt.m in Sources */,
 				59BBED28278493E400BA9CD6 /* indigo_agent_astap.c in Sources */,
 				9D62F70228FEAF62006599FF /* indigo_agent_config.c in Sources */,
-				598A1BC5259BA94A00C0B34C /* indigo_ccd_ptp.c in Sources */,
 				598A1BC6259BA94A00C0B34C /* indigo_mount_synscan_guider.c in Sources */,
 				598A1BC7259BA94A00C0B34C /* indigo_agent_snoop.c in Sources */,
 				598A1BC8259BA94A00C0B34C /* indigo_ser.c in Sources */,
@@ -14479,7 +14486,6 @@
 				59D8BBC6260E624600B904EE /* alpaca_dome.c in Sources */,
 				598A1BCE259BA94A00C0B34C /* indigo_focuser_dmfc.c in Sources */,
 				598A1BCF259BA94A00C0B34C /* indigo_mount_driver.c in Sources */,
-				598A1BD0259BA94A00C0B34C /* indigo_ica_ptp.m in Sources */,
 				598A1BD1259BA94A00C0B34C /* indigo_json.c in Sources */,
 				598A1BD2259BA94A00C0B34C /* indigo_server_tcp.c in Sources */,
 				598A1BD3259BA94A00C0B34C /* indigo_mount_synscan_protocol.c in Sources */,
@@ -14505,7 +14511,6 @@
 				598A1BE1259BA94A00C0B34C /* libuvc_frame_mjpeg.c in Sources */,
 				598A1BE2259BA94A00C0B34C /* indigo_mount_lx200.c in Sources */,
 				591CD0E929805CBA003243AE /* indigo_ccd_rising.c in Sources */,
-				598A1BE3259BA94A00C0B34C /* indigo_ica_ptp_nikon.m in Sources */,
 				5955CB7E2684E93F00685071 /* indigo_aux_astromechanics.c in Sources */,
 				598A1BE4259BA94A00C0B34C /* indigo_wheel_atik.c in Sources */,
 				598A1BE5259BA94A00C0B34C /* DDHidDevice.m in Sources */,
@@ -14526,6 +14531,7 @@
 				598A1BF1259BA94A00C0B34C /* DDHidAppleRemote.m in Sources */,
 				598A1BF2259BA94A00C0B34C /* indigo_aux_flipflat.c in Sources */,
 				597BD1B5260A597400239274 /* alpaca_guider.c in Sources */,
+				9DA71CF42A025A0B00CFA533 /* indigo_ptp.c in Sources */,
 				5995A8D925A9AC69003987F1 /* indigo_platesolver.c in Sources */,
 				59111CEA285F504200E57194 /* indigocat_sun.c in Sources */,
 				598A1BF3259BA94A00C0B34C /* indigo_system_ascol.c in Sources */,
@@ -14570,6 +14576,7 @@
 				59986D761F9BA11600D68DC1 /* indigo_ccd_qsi.cpp in Sources */,
 				59C8E7C11DBBB05500AA3F0A /* indigo_ccd_simulator.c in Sources */,
 				59EF8BC924683B2A009D75C5 /* indigo_dome_baader.c in Sources */,
+				9DA71D072A029BE500CFA533 /* indigo_ica_ptp_canon.m in Sources */,
 				591F329324211F3C00D1D64B /* indigo_dome_dragonfly.c in Sources */,
 				59FA0B2022FCACC700A15D19 /* indigo_ptp_canon.c in Sources */,
 				9D62F70128FEAF62006599FF /* indigo_agent_config.c in Sources */,
@@ -14597,6 +14604,7 @@
 				9DAD523121246EB5002FCC79 /* indigo_mount_ioptron.c in Sources */,
 				59DD69C91FC1CF8D00AEF0DF /* indigo_gps_nmea.c in Sources */,
 				590B59D41F7858FE00086FD2 /* indigo_mount_temma.c in Sources */,
+				9DA71CF32A025A0A00CFA533 /* indigo_ptp.c in Sources */,
 				59D6718E22FDBB7500D08A2A /* indigo_ptp_nikon.c in Sources */,
 				595F292E211E211200380EF4 /* DDHidElement.m in Sources */,
 				9D4F4742215A4447006110FD /* indigo_focuser_moonlite.c in Sources */,
@@ -14607,6 +14615,7 @@
 				5992F7BD1E1EC95D0035242E /* indigo_wheel_fli.c in Sources */,
 				59F682AB250FE9C400ABD731 /* indigo_focuser_robofocus.c in Sources */,
 				595F292F211E211200380EF4 /* DDHidUsage.m in Sources */,
+				9DA71D0A2A029BE500CFA533 /* indigo_ica_ptp_sony.m in Sources */,
 				59EFE8A62363483000ED5337 /* indigo_focuser_focusdreampro.c in Sources */,
 				59A413382971E54C00F0A80B /* Makefile.inc in Sources */,
 				599E6A77214D8EFF00E45C9E /* indigo_focuser_nstep.c in Sources */,
@@ -14630,10 +14639,8 @@
 				5911B6D922633DBE00D6B9EC /* indigo_agent_guider.c in Sources */,
 				59111CFB285F504300E57194 /* indigocat_saturn.c in Sources */,
 				5951E149235CDC0400D2DEF1 /* indigo_aux_usbdp.c in Sources */,
-				9D586C4522FC6265002D382E /* indigo_ptp.c in Sources */,
 				599C9A4E1DA022E3008BBCC1 /* indigo_bus.c in Sources */,
 				59BBD186218236C4008199D6 /* indigo_ccd_altair.c in Sources */,
-				59C499E61EFADFE000E750AA /* indigo_ccd_ica.m in Sources */,
 				59F4EC731E941D2500CC7772 /* indigo_ccd_sbig.c in Sources */,
 				592E79192168E06B00E856F3 /* indigo_focuser_mjkzz.c in Sources */,
 				5973456F256704D6001741D4 /* indigo_focuser_mypro2.c in Sources */,
@@ -14654,6 +14661,7 @@
 				9DBC34661DCB267700588DB9 /* indigo_wheel_asi.c in Sources */,
 				5979C88B254A9EED005395BE /* indigo_wheel_qhy.c in Sources */,
 				59019E0B1DE0AC7400CCB3ED /* indigo_client.c in Sources */,
+				9DA71D092A029BE500CFA533 /* indigo_ica_ptp_nikon.m in Sources */,
 				595F291F211E211100380EF4 /* DDHidJoystick.m in Sources */,
 				9D9EA6A51DBE1F7300E11841 /* indigo_ccd_atik.c in Sources */,
 				5996615822CF44D500330652 /* indigo_aux_ppb.c in Sources */,
@@ -14672,7 +14680,6 @@
 				9D743A5B23FD57F80093319F /* indigo_rotator_driver.c in Sources */,
 				9D73E61621FF37F9003CEC15 /* libuvc_ctrl.c in Sources */,
 				59790B3029B2798A00F73B1D /* indigo_service_discovery.c in Sources */,
-				59CC779D1F27BD07003AD2DB /* indigo_ica_ptp_sony.m in Sources */,
 				5955CB6A2684BC9C00685071 /* indigo_dome_beaver.c in Sources */,
 				9D69408F2180BAF700AB112C /* indigo_aux_upb.c in Sources */,
 				9DAD522221246C18002FCC79 /* indigo_mount_synscan.c in Sources */,
@@ -14707,27 +14714,28 @@
 				9DDBAE191E2D2099004FE70F /* indigo_timer.c in Sources */,
 				59111CFC285F504300E57194 /* indigocat_vsop87.c in Sources */,
 				591CD11129806D41003243AE /* indigo_ccd_mallin.c in Sources */,
+				9DA71D022A029BE500CFA533 /* indigo_ica_ptp.m in Sources */,
 				594122A11FD2DE7800D792FF /* indigo_dome_azimuth.c in Sources */,
 				595567D824BA00DA00DF303D /* indigo_mount_pmc8_main.c in Sources */,
 				59D62CDB1E731B62004DDD9C /* indigo_focuser_usbv3.c in Sources */,
 				59FE347C2187B7DD004FB5D4 /* indigo_guider_gpusb.c in Sources */,
 				599C9A511DA022E3008BBCC1 /* indigo_driver_xml.c in Sources */,
 				5910D9B7258008190015D915 /* indigo_agent_scripting.c in Sources */,
-				59E38B541F1577A000187839 /* indigo_ica_ptp_canon.m in Sources */,
 				59111D02285F504300E57194 /* indigocat_mars.c in Sources */,
 				59C76F11237872520091B966 /* nexstar_pec.c in Sources */,
 				9D9EA6B61DBFA30600E11841 /* indigo_wheel_driver.c in Sources */,
 				59463C1B20DE6781004950F2 /* indigo_focuser_wemacro_bt.m in Sources */,
 				59B51350297066040075C8A1 /* indigo_wheel_indigo.c in Sources */,
-				9D586C4122FB0D43002D382E /* indigo_ccd_ptp.c in Sources */,
 				59BBED27278493E400BA9CD6 /* indigo_agent_astap.c in Sources */,
 				59D138A5283E6BAA00FCC514 /* indigo_dslr_raw.c in Sources */,
+				9DA71D012A029BE500CFA533 /* indigo_ccd_ica.m in Sources */,
 				59A321B821D691D600EC0F4A /* indigo_mount_synscan_guider.c in Sources */,
 				595AA1CD1FC5ED8A00350E7B /* indigo_agent_snoop.c in Sources */,
 				59C3BAFD254DE8AD000720B4 /* indigo_ser.c in Sources */,
 				59111CFE285F504300E57194 /* indigocat_transform.c in Sources */,
 				9D9EA6B41DBFA30600E11841 /* indigo_guider_driver.c in Sources */,
 				595F2926211E211200380EF4 /* DDHidMouse.m in Sources */,
+				9DA71CF12A0255A900CFA533 /* indigo_ccd_ptp.m in Sources */,
 				9D7244F421F1CFEC0028FDF4 /* indigo_agent_mount.c in Sources */,
 				59F7E5EA2457669D00EF273A /* indigo_aux_cloudwatcher.c in Sources */,
 				5955CB7D2684E93E00685071 /* indigo_aux_astromechanics.c in Sources */,
@@ -14738,7 +14746,6 @@
 				5913653928CFB42000ABB99B /* indigo_md5.c in Sources */,
 				59540AD626D00CCF000C2A1B /* indigo_aux_geoptikflat.c in Sources */,
 				59D707691DC527B800DEF566 /* indigo_mount_driver.c in Sources */,
-				59C499E81EFADFE000E750AA /* indigo_ica_ptp.m in Sources */,
 				599A63A71DE8BD1700ABC827 /* indigo_json.c in Sources */,
 				599C9A531DA022E3008BBCC1 /* indigo_server_tcp.c in Sources */,
 				9DAD522321246C18002FCC79 /* indigo_mount_synscan_protocol.c in Sources */,
@@ -14759,7 +14766,6 @@
 				59588CB0211CC30C00E9FC27 /* indigo_aux_driver.c in Sources */,
 				9D73E61721FF37F9003CEC15 /* libuvc_frame_mjpeg.c in Sources */,
 				9DB918031DF8546800678721 /* indigo_mount_lx200.c in Sources */,
-				59E38B561F1577A000187839 /* indigo_ica_ptp_nikon.m in Sources */,
 				593CFE441DFC8A12003B63D4 /* indigo_wheel_atik.c in Sources */,
 				595F2930211E211200380EF4 /* DDHidDevice.m in Sources */,
 				593AD1051EF8399F00C059BC /* indigo_guider_asi.c in Sources */,

--- a/indigo.xcodeproj/project.pbxproj
+++ b/indigo.xcodeproj/project.pbxproj
@@ -125,18 +125,6 @@
 		592E79192168E06B00E856F3 /* indigo_focuser_mjkzz.c in Sources */ = {isa = PBXBuildFile; fileRef = 592E79162168DD7A00E856F3 /* indigo_focuser_mjkzz.c */; };
 		5931B7282535FA8A008F74A1 /* libindigo.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 5931B7272535FA8A008F74A1 /* libindigo.dylib */; };
 		593287A62409AD1000ED61C0 /* indigo_rotator_lunatico.c in Sources */ = {isa = PBXBuildFile; fileRef = 593287A22409ACC700ED61C0 /* indigo_rotator_lunatico.c */; };
-		5937CBE22A02BE9800135CCF /* indigo_ptp.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBE12A02BE9800135CCF /* indigo_ptp.m */; };
-		5937CBE32A02BE9800135CCF /* indigo_ptp.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBE12A02BE9800135CCF /* indigo_ptp.m */; };
-		5937CBE52A02BED800135CCF /* indigo_ptp_canon.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBE42A02BED800135CCF /* indigo_ptp_canon.m */; };
-		5937CBE62A02BED800135CCF /* indigo_ptp_canon.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBE42A02BED800135CCF /* indigo_ptp_canon.m */; };
-		5937CBE82A02BEE100135CCF /* indigo_ptp_nikon.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBE72A02BEE100135CCF /* indigo_ptp_nikon.m */; };
-		5937CBE92A02BEE100135CCF /* indigo_ptp_nikon.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBE72A02BEE100135CCF /* indigo_ptp_nikon.m */; };
-		5937CBEB2A02BEEB00135CCF /* indigo_ptp_sony.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBEA2A02BEEB00135CCF /* indigo_ptp_sony.m */; };
-		5937CBEC2A02BEEB00135CCF /* indigo_ptp_sony.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBEA2A02BEEB00135CCF /* indigo_ptp_sony.m */; };
-		5937CBEE2A02BEF700135CCF /* indigo_ptp_fuji.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBED2A02BEF700135CCF /* indigo_ptp_fuji.m */; };
-		5937CBEF2A02BEF700135CCF /* indigo_ptp_fuji.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBED2A02BEF700135CCF /* indigo_ptp_fuji.m */; };
-		5937CBF42A02C25900135CCF /* indigo_ptp_ica.h in Headers */ = {isa = PBXBuildFile; fileRef = 5937CBF32A02C25900135CCF /* indigo_ptp_ica.h */; };
-		5937CBF52A02C25900135CCF /* indigo_ptp_ica.h in Headers */ = {isa = PBXBuildFile; fileRef = 5937CBF32A02C25900135CCF /* indigo_ptp_ica.h */; };
 		59399D902177D67C002886CA /* indigo_focuser_optec.c in Sources */ = {isa = PBXBuildFile; fileRef = 59399D892177D316002886CA /* indigo_focuser_optec.c */; };
 		593A357E219DBAD500EDF481 /* indigo_filter.h in Headers */ = {isa = PBXBuildFile; fileRef = 593A357A219DB4BA00EDF481 /* indigo_filter.h */; };
 		593A3580219DBE5E00EDF481 /* indigo_filter.c in Sources */ = {isa = PBXBuildFile; fileRef = 593A357B219DB4BA00EDF481 /* indigo_filter.c */; };
@@ -623,6 +611,20 @@
 		599C9A521DA022E3008BBCC1 /* indigo_client_xml.c in Sources */ = {isa = PBXBuildFile; fileRef = 59D382061D97314C00E87393 /* indigo_client_xml.c */; };
 		599C9A531DA022E3008BBCC1 /* indigo_server_tcp.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D97F8061D9A89ED00582EAF /* indigo_server_tcp.c */; };
 		599E6A77214D8EFF00E45C9E /* indigo_focuser_nstep.c in Sources */ = {isa = PBXBuildFile; fileRef = 599E6A76214D8EEB00E45C9E /* indigo_focuser_nstep.c */; };
+		599FC6862A0437F60030ED16 /* indigo_ptp.h in Headers */ = {isa = PBXBuildFile; fileRef = 59FA0B1C22FB400900A15D19 /* indigo_ptp.h */; };
+		599FC68D2A0437F80030ED16 /* indigo_ptp.h in Headers */ = {isa = PBXBuildFile; fileRef = 59FA0B1C22FB400900A15D19 /* indigo_ptp.h */; };
+		599FC68E2A0438700030ED16 /* indigo_ptp_sony.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBEA2A02BEEB00135CCF /* indigo_ptp_sony.m */; };
+		599FC68F2A0438700030ED16 /* indigo_ptp.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBE12A02BE9800135CCF /* indigo_ptp.m */; };
+		599FC6902A0438700030ED16 /* indigo_ptp_canon.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBE42A02BED800135CCF /* indigo_ptp_canon.m */; };
+		599FC6912A0438700030ED16 /* indigo_ptp_fuji.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBED2A02BEF700135CCF /* indigo_ptp_fuji.m */; };
+		599FC6922A0438700030ED16 /* indigo_ccd_ptp.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DA71CF02A0255A900CFA533 /* indigo_ccd_ptp.m */; };
+		599FC6932A0438700030ED16 /* indigo_ptp_nikon.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBE72A02BEE100135CCF /* indigo_ptp_nikon.m */; };
+		599FC6942A0438710030ED16 /* indigo_ptp_sony.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBEA2A02BEEB00135CCF /* indigo_ptp_sony.m */; };
+		599FC6952A0438710030ED16 /* indigo_ptp.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBE12A02BE9800135CCF /* indigo_ptp.m */; };
+		599FC6962A0438710030ED16 /* indigo_ptp_canon.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBE42A02BED800135CCF /* indigo_ptp_canon.m */; };
+		599FC6972A0438710030ED16 /* indigo_ptp_fuji.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBED2A02BEF700135CCF /* indigo_ptp_fuji.m */; };
+		599FC6982A0438710030ED16 /* indigo_ccd_ptp.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DA71CF02A0255A900CFA533 /* indigo_ccd_ptp.m */; };
+		599FC6992A0438710030ED16 /* indigo_ptp_nikon.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBE72A02BEE100135CCF /* indigo_ptp_nikon.m */; };
 		59A21E7D25BD849F00005965 /* libnovas.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9DDEFC1D21EE39B300657C8F /* libnovas.a */; };
 		59A242DA22A2C6AE001C38F8 /* indigo_system_ascol.c in Sources */ = {isa = PBXBuildFile; fileRef = 9DC782F621A6FCC7009859FD /* indigo_system_ascol.c */; };
 		59A242E322A2C6CE001C38F8 /* libascol.c in Sources */ = {isa = PBXBuildFile; fileRef = 9DC782F921A6FCC7009859FD /* libascol.c */; };
@@ -843,8 +845,6 @@
 		9D9EA6B71DBFA30600E11841 /* indigo_wheel_driver.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D9EA6B11DBFA30600E11841 /* indigo_wheel_driver.h */; };
 		9DA451CE21908CBC00818B58 /* indigo_agent_imager.c in Sources */ = {isa = PBXBuildFile; fileRef = 9DA451CC21908CBC00818B58 /* indigo_agent_imager.c */; };
 		9DA451CF21908CBC00818B58 /* indigo_agent_imager.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DA451CD21908CBC00818B58 /* indigo_agent_imager.h */; };
-		9DA71CF12A0255A900CFA533 /* indigo_ccd_ptp.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DA71CF02A0255A900CFA533 /* indigo_ccd_ptp.m */; };
-		9DA71CF22A0255A900CFA533 /* indigo_ccd_ptp.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DA71CF02A0255A900CFA533 /* indigo_ccd_ptp.m */; };
 		9DA71D012A029BE500CFA533 /* indigo_ccd_ica.m in Sources */ = {isa = PBXBuildFile; fileRef = 59C499E21EFADFE000E750AA /* indigo_ccd_ica.m */; };
 		9DA71D022A029BE500CFA533 /* indigo_ica_ptp.m in Sources */ = {isa = PBXBuildFile; fileRef = 59C499E41EFADFE000E750AA /* indigo_ica_ptp.m */; };
 		9DA71D032A029BE500CFA533 /* indigo_ica_ptp_canon.h in Headers */ = {isa = PBXBuildFile; fileRef = 59E38B4F1F1577A000187839 /* indigo_ica_ptp_canon.h */; };
@@ -13718,7 +13718,6 @@
 				59B8A8C827ADAD8400A27609 /* indigo_align.h in Headers */,
 				598A1C1B259BA94A00C0B34C /* libdsusb.h in Headers */,
 				591CD0CD298042C1003243AE /* starshootg.h in Headers */,
-				5937CBF52A02C25900135CCF /* indigo_ptp_ica.h in Headers */,
 				598A1C1C259BA94A00C0B34C /* duk_config.h in Headers */,
 				598A1C1D259BA94A00C0B34C /* DDHidUsageTables.h in Headers */,
 				598A1C1E259BA94A00C0B34C /* indigo_driver_json.h in Headers */,
@@ -13755,6 +13754,7 @@
 				598A1C36259BA94A00C0B34C /* DDHidJoystick.h in Headers */,
 				598A1C37259BA94A00C0B34C /* libuvc_config.h in Headers */,
 				598A1C38259BA94A00C0B34C /* DDHidMouse.h in Headers */,
+				599FC68D2A0437F80030ED16 /* indigo_ptp.h in Headers */,
 				598A1C39259BA94A00C0B34C /* EFW_filter.h in Headers */,
 				591CD0E729805CB6003243AE /* indigo_ccd_rising.h in Headers */,
 				59958E3425CC833C00BEFA1B /* indigo_aux_skyalert.h in Headers */,
@@ -14020,7 +14020,6 @@
 				5911B6DA22633DBE00D6B9EC /* indigo_agent_guider.h in Headers */,
 				595F2920211E211100380EF4 /* DDHidQueue.h in Headers */,
 				595F2919211E211100380EF4 /* NSDictionary+DDHidExtras.h in Headers */,
-				5937CBF42A02C25900135CCF /* indigo_ptp_ica.h in Headers */,
 				59A52D6521A33617000B6F27 /* gxccd.h in Headers */,
 				59D7076A1DC527B800DEF566 /* indigo_mount_driver.h in Headers */,
 				9DAD52472126BD99002FCC79 /* indigo_wheel_quantum.h in Headers */,
@@ -14054,6 +14053,7 @@
 				595F2921211E211100380EF4 /* DDHidAppleMikey.h in Headers */,
 				593A357E219DBAD500EDF481 /* indigo_filter.h in Headers */,
 				59FFB065288D3D3600F172AC /* indigo_ccd_playerone.h in Headers */,
+				599FC6862A0437F60030ED16 /* indigo_ptp.h in Headers */,
 				59C76F10237872520091B966 /* config.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -14336,7 +14336,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5937CBE62A02BED800135CCF /* indigo_ptp_canon.m in Sources */,
+				599FC6962A0438710030ED16 /* indigo_ptp_canon.m in Sources */,
 				59111CF2285F504200E57194 /* indigocat_earth.c in Sources */,
 				598A1B54259BA94A00C0B34C /* libuvc_misc.c in Sources */,
 				598A1B55259BA94A00C0B34C /* indigo_ccd_qhy.cpp in Sources */,
@@ -14366,6 +14366,7 @@
 				9DA71D142A029BE600CFA533 /* indigo_ica_ptp_sony.m in Sources */,
 				598A1B68259BA94A00C0B34C /* indigo_mount_ioptron.c in Sources */,
 				598A1B69259BA94A00C0B34C /* indigo_gps_nmea.c in Sources */,
+				599FC6992A0438710030ED16 /* indigo_ptp_nikon.m in Sources */,
 				593A8F11285F616F00F6CF1C /* indigocat_precession.c in Sources */,
 				598A1B6A259BA94A00C0B34C /* indigo_mount_temma.c in Sources */,
 				598A1B6C259BA94A00C0B34C /* DDHidElement.m in Sources */,
@@ -14393,6 +14394,7 @@
 				597BD19E2606974900239274 /* alpaca_lightbox.c in Sources */,
 				598A1B7E259BA94A00C0B34C /* indigo_gps_gpsd.c in Sources */,
 				598A1B7F259BA94A00C0B34C /* indigo_focuser_asi.c in Sources */,
+				599FC6952A0438710030ED16 /* indigo_ptp.m in Sources */,
 				597BD16426013CDD00239274 /* indigo_agent_alpaca.c in Sources */,
 				598A1B80259BA94A00C0B34C /* indigo_agent_guider.c in Sources */,
 				598A1B81259BA94A00C0B34C /* indigo_aux_usbdp.c in Sources */,
@@ -14413,7 +14415,6 @@
 				598A1B90259BA94A00C0B34C /* NSXReturnThrowError.m in Sources */,
 				598A1B91259BA94A00C0B34C /* indigo_mount_synscan_mount.c in Sources */,
 				598A1B92259BA94A00C0B34C /* indigo_rotator_lunatico.c in Sources */,
-				9DA71CF22A0255A900CFA533 /* indigo_ccd_ptp.m in Sources */,
 				598A1B93259BA94A00C0B34C /* indigo_ao_driver.c in Sources */,
 				597DFE252804A880009E37CB /* indigo_rotator_optec.c in Sources */,
 				9DA71D132A029BE600CFA533 /* indigo_ica_ptp_nikon.m in Sources */,
@@ -14429,7 +14430,6 @@
 				598A1B9B259BA94A00C0B34C /* indigo_agent_lx200_server.c in Sources */,
 				598A1B9C259BA94A00C0B34C /* libdsi.c in Sources */,
 				598A1B9D259BA94A00C0B34C /* nexstar.c in Sources */,
-				5937CBE92A02BEE100135CCF /* indigo_ptp_nikon.m in Sources */,
 				9DA71D0B2A029BE600CFA533 /* indigo_ccd_ica.m in Sources */,
 				598A1B9E259BA94A00C0B34C /* DDHidAppleMikey.m in Sources */,
 				591CCFAD2980396B003243AE /* indigo_ccd_omegonpro.c in Sources */,
@@ -14454,7 +14454,6 @@
 				59111CF3285F504200E57194 /* indigocat_mars.c in Sources */,
 				59F6BB42261CA65800DA9BE1 /* alpaca_switch.c in Sources */,
 				598A1BAB259BA94A00C0B34C /* indigo_aux_dragonfly.c in Sources */,
-				5937CBE32A02BE9800135CCF /* indigo_ptp.m in Sources */,
 				598A1BAC259BA94A00C0B34C /* DDHidKeyboard.m in Sources */,
 				598A1BAD259BA94A00C0B34C /* indigo_wheel_optec.c in Sources */,
 				598A1BAE259BA94A00C0B34C /* indigo_aux_arteskyflat.c in Sources */,
@@ -14469,7 +14468,6 @@
 				598A1BB4259BA94A00C0B34C /* indigo_aux_rts.c in Sources */,
 				598A1BB5259BA94A00C0B34C /* duktape.c in Sources */,
 				598A1BB6259BA94A00C0B34C /* DDHidQueue.m in Sources */,
-				5937CBEC2A02BEEB00135CCF /* indigo_ptp_sony.m in Sources */,
 				598A1BB7259BA94A00C0B34C /* indigo_mount_rainbow.c in Sources */,
 				594EF31D2770FD58002D0EC8 /* indigo_align.c in Sources */,
 				598A1BB8259BA94A00C0B34C /* indigo_ccd_simulator_data.c in Sources */,
@@ -14490,6 +14488,7 @@
 				59111CF0285F504200E57194 /* indigocat_nutation.c in Sources */,
 				59111CE8285F504200E57194 /* indigocat_neptune.c in Sources */,
 				598A1BC3259BA94A00C0B34C /* indigo_wheel_driver.c in Sources */,
+				599FC6972A0438710030ED16 /* indigo_ptp_fuji.m in Sources */,
 				598A1BC4259BA94A00C0B34C /* indigo_focuser_wemacro_bt.m in Sources */,
 				59BBED28278493E400BA9CD6 /* indigo_agent_astap.c in Sources */,
 				9D62F70228FEAF62006599FF /* indigo_agent_config.c in Sources */,
@@ -14505,7 +14504,9 @@
 				598A1BCE259BA94A00C0B34C /* indigo_focuser_dmfc.c in Sources */,
 				598A1BCF259BA94A00C0B34C /* indigo_mount_driver.c in Sources */,
 				598A1BD1259BA94A00C0B34C /* indigo_json.c in Sources */,
+				599FC6982A0438710030ED16 /* indigo_ccd_ptp.m in Sources */,
 				598A1BD2259BA94A00C0B34C /* indigo_server_tcp.c in Sources */,
+				599FC6942A0438710030ED16 /* indigo_ptp_sony.m in Sources */,
 				598A1BD3259BA94A00C0B34C /* indigo_mount_synscan_protocol.c in Sources */,
 				598A1BD4259BA94A00C0B34C /* indigo_agent_auxiliary.c in Sources */,
 				598A1BD5259BA94A00C0B34C /* indigo_agent.c in Sources */,
@@ -14521,7 +14522,6 @@
 				598A1BDC259BA94A00C0B34C /* indigo_focuser_optec.c in Sources */,
 				598A1BDD259BA94A00C0B34C /* indigo_focuser_lakeside.c in Sources */,
 				59D2B9E8294A2B22002F0F90 /* indigo_ccd_asi.c in Sources */,
-				5937CBEF2A02BEF700135CCF /* indigo_ptp_fuji.m in Sources */,
 				598A1BDE259BA94A00C0B34C /* indigo_dome_nexdome3.c in Sources */,
 				598A1BDF259BA94A00C0B34C /* indigo_wheel_xagyl.c in Sources */,
 				591CD11329806D42003243AE /* indigo_ccd_mallin.c in Sources */,
@@ -14590,7 +14590,6 @@
 			files = (
 				59D29A1B2841469D00D5E7F7 /* indigo_mount_starbook.c in Sources */,
 				9D73E61B21FF37F9003CEC15 /* libuvc_misc.c in Sources */,
-				5937CBE22A02BE9800135CCF /* indigo_ptp.m in Sources */,
 				595567CE24B88F5B00DF303D /* indigo_ccd_qhy.cpp in Sources */,
 				59986D761F9BA11600D68DC1 /* indigo_ccd_qsi.cpp in Sources */,
 				59C8E7C11DBBB05500AA3F0A /* indigo_ccd_simulator.c in Sources */,
@@ -14614,7 +14613,6 @@
 				59111D03285F504300E57194 /* indigocat_uranus.c in Sources */,
 				59C76F0E2378724D0091B966 /* nex_open.c in Sources */,
 				59D707701DC52C3E00DEF566 /* indigo_mount_simulator.c in Sources */,
-				5937CBE82A02BEE100135CCF /* indigo_ptp_nikon.m in Sources */,
 				591CD0E829805CB9003243AE /* indigo_ccd_rising.c in Sources */,
 				597DFE242804A880009E37CB /* indigo_rotator_optec.c in Sources */,
 				9D73E61E21FF37F9003CEC15 /* libuvc_stream.c in Sources */,
@@ -14667,6 +14665,7 @@
 				590BF1B421EBCF7500C24DBA /* indigo_ao_sx.c in Sources */,
 				598FE2752614F91A00E0DA21 /* indigo_dome_talon6ror.c in Sources */,
 				597BD19326067B0100239274 /* alpaca_focuser.c in Sources */,
+				599FC6922A0438700030ED16 /* indigo_ccd_ptp.m in Sources */,
 				59C8E7FB1DBBDF7A00AA3F0A /* indigo_wheel_sx.c in Sources */,
 				595F2923211E211200380EF4 /* NSXReturnThrowError.m in Sources */,
 				59111CFA285F504300E57194 /* indigocat_venus.c in Sources */,
@@ -14714,6 +14713,7 @@
 				59B81EC523376FE000DFA81B /* indigo_aux_arteskyflat.c in Sources */,
 				59111CFD285F504300E57194 /* indigocat_jupiter.c in Sources */,
 				9D61B9DF216DE636000DE7E8 /* indigo_focuser_mjkzz_bt.m in Sources */,
+				599FC6912A0438700030ED16 /* indigo_ptp_fuji.m in Sources */,
 				593A3580219DBE5E00EDF481 /* indigo_filter.c in Sources */,
 				9D9EA6B21DBFA30600E11841 /* indigo_ccd_driver.c in Sources */,
 				599C9A501DA022E3008BBCC1 /* indigo_xml.c in Sources */,
@@ -14734,17 +14734,17 @@
 				595567D824BA00DA00DF303D /* indigo_mount_pmc8_main.c in Sources */,
 				59D62CDB1E731B62004DDD9C /* indigo_focuser_usbv3.c in Sources */,
 				59FE347C2187B7DD004FB5D4 /* indigo_guider_gpusb.c in Sources */,
-				5937CBEE2A02BEF700135CCF /* indigo_ptp_fuji.m in Sources */,
 				599C9A511DA022E3008BBCC1 /* indigo_driver_xml.c in Sources */,
 				5910D9B7258008190015D915 /* indigo_agent_scripting.c in Sources */,
 				59111D02285F504300E57194 /* indigocat_mars.c in Sources */,
 				59C76F11237872520091B966 /* nexstar_pec.c in Sources */,
+				599FC68F2A0438700030ED16 /* indigo_ptp.m in Sources */,
+				599FC68E2A0438700030ED16 /* indigo_ptp_sony.m in Sources */,
 				9D9EA6B61DBFA30600E11841 /* indigo_wheel_driver.c in Sources */,
 				59463C1B20DE6781004950F2 /* indigo_focuser_wemacro_bt.m in Sources */,
 				59B51350297066040075C8A1 /* indigo_wheel_indigo.c in Sources */,
 				59BBED27278493E400BA9CD6 /* indigo_agent_astap.c in Sources */,
 				59D138A5283E6BAA00FCC514 /* indigo_dslr_raw.c in Sources */,
-				5937CBEB2A02BEEB00135CCF /* indigo_ptp_sony.m in Sources */,
 				9DA71D012A029BE500CFA533 /* indigo_ccd_ica.m in Sources */,
 				59A321B821D691D600EC0F4A /* indigo_mount_synscan_guider.c in Sources */,
 				595AA1CD1FC5ED8A00350E7B /* indigo_agent_snoop.c in Sources */,
@@ -14752,7 +14752,6 @@
 				59111CFE285F504300E57194 /* indigocat_transform.c in Sources */,
 				9D9EA6B41DBFA30600E11841 /* indigo_guider_driver.c in Sources */,
 				595F2926211E211200380EF4 /* DDHidMouse.m in Sources */,
-				9DA71CF12A0255A900CFA533 /* indigo_ccd_ptp.m in Sources */,
 				9D7244F421F1CFEC0028FDF4 /* indigo_agent_mount.c in Sources */,
 				59F7E5EA2457669D00EF273A /* indigo_aux_cloudwatcher.c in Sources */,
 				5955CB7D2684E93E00685071 /* indigo_aux_astromechanics.c in Sources */,
@@ -14797,6 +14796,7 @@
 				595F291A211E211100380EF4 /* DDHidEvent.m in Sources */,
 				9D4D64B320A9D947008ECE4B /* indigo_guider_eqmac.c in Sources */,
 				5911F7B31F02E1390053F3CA /* indigo_ccd_dsi.c in Sources */,
+				599FC6932A0438700030ED16 /* indigo_ptp_nikon.m in Sources */,
 				9DAC59D31DC0A8AD00AE410D /* indigo_focuser_driver.c in Sources */,
 				9DB918081DFEA42E00678721 /* indigo_io.c in Sources */,
 				9DAD522621246C18002FCC79 /* indigo_mount_synscan_driver.c in Sources */,
@@ -14812,7 +14812,7 @@
 				5979C862254710B0005395BE /* indigo_tiff.c in Sources */,
 				9D48B7B6215E5B6100CF757E /* indigo_ccd_touptek.c in Sources */,
 				9DE0E7C222C6465500289234 /* indigo_focuser_dsd.c in Sources */,
-				5937CBE52A02BED800135CCF /* indigo_ptp_canon.m in Sources */,
+				599FC6902A0438700030ED16 /* indigo_ptp_canon.m in Sources */,
 				59B636B020A74CD400EF2D52 /* indigo_usb_utils.c in Sources */,
 				595B88EC242CFEA2008CA4E2 /* indigo_token.c in Sources */,
 				59F1AD1223FB15B300008F02 /* indigo_focuser_lunatico.c in Sources */,

--- a/indigo.xcodeproj/project.pbxproj
+++ b/indigo.xcodeproj/project.pbxproj
@@ -613,18 +613,6 @@
 		599E6A77214D8EFF00E45C9E /* indigo_focuser_nstep.c in Sources */ = {isa = PBXBuildFile; fileRef = 599E6A76214D8EEB00E45C9E /* indigo_focuser_nstep.c */; };
 		599FC6862A0437F60030ED16 /* indigo_ptp.h in Headers */ = {isa = PBXBuildFile; fileRef = 59FA0B1C22FB400900A15D19 /* indigo_ptp.h */; };
 		599FC68D2A0437F80030ED16 /* indigo_ptp.h in Headers */ = {isa = PBXBuildFile; fileRef = 59FA0B1C22FB400900A15D19 /* indigo_ptp.h */; };
-		599FC68E2A0438700030ED16 /* indigo_ptp_sony.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBEA2A02BEEB00135CCF /* indigo_ptp_sony.m */; };
-		599FC68F2A0438700030ED16 /* indigo_ptp.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBE12A02BE9800135CCF /* indigo_ptp.m */; };
-		599FC6902A0438700030ED16 /* indigo_ptp_canon.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBE42A02BED800135CCF /* indigo_ptp_canon.m */; };
-		599FC6912A0438700030ED16 /* indigo_ptp_fuji.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBED2A02BEF700135CCF /* indigo_ptp_fuji.m */; };
-		599FC6922A0438700030ED16 /* indigo_ccd_ptp.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DA71CF02A0255A900CFA533 /* indigo_ccd_ptp.m */; };
-		599FC6932A0438700030ED16 /* indigo_ptp_nikon.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBE72A02BEE100135CCF /* indigo_ptp_nikon.m */; };
-		599FC6942A0438710030ED16 /* indigo_ptp_sony.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBEA2A02BEEB00135CCF /* indigo_ptp_sony.m */; };
-		599FC6952A0438710030ED16 /* indigo_ptp.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBE12A02BE9800135CCF /* indigo_ptp.m */; };
-		599FC6962A0438710030ED16 /* indigo_ptp_canon.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBE42A02BED800135CCF /* indigo_ptp_canon.m */; };
-		599FC6972A0438710030ED16 /* indigo_ptp_fuji.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBED2A02BEF700135CCF /* indigo_ptp_fuji.m */; };
-		599FC6982A0438710030ED16 /* indigo_ccd_ptp.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DA71CF02A0255A900CFA533 /* indigo_ccd_ptp.m */; };
-		599FC6992A0438710030ED16 /* indigo_ptp_nikon.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBE72A02BEE100135CCF /* indigo_ptp_nikon.m */; };
 		59A21E7D25BD849F00005965 /* libnovas.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9DDEFC1D21EE39B300657C8F /* libnovas.a */; };
 		59A242DA22A2C6AE001C38F8 /* indigo_system_ascol.c in Sources */ = {isa = PBXBuildFile; fileRef = 9DC782F621A6FCC7009859FD /* indigo_system_ascol.c */; };
 		59A242E322A2C6CE001C38F8 /* libascol.c in Sources */ = {isa = PBXBuildFile; fileRef = 9DC782F921A6FCC7009859FD /* libascol.c */; };
@@ -766,6 +754,20 @@
 		59E5A2A323C125A300E8BBBF /* indigo_mount_rainbow.c in Sources */ = {isa = PBXBuildFile; fileRef = 59E5A29823C1238400E8BBBF /* indigo_mount_rainbow.c */; };
 		59E6B7FA27E3835E007A2A7B /* indigo_ccd_mi.c in Sources */ = {isa = PBXBuildFile; fileRef = 59FC2EB6210CA76100730343 /* indigo_ccd_mi.c */; };
 		59E6B7FB27E383B9007A2A7B /* libgxccd.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 59A52D5B21A3360B000B6F27 /* libgxccd.a */; };
+		59EEB53B2A059367008A8D16 /* indigo_ptp.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBE12A02BE9800135CCF /* indigo_ptp.m */; };
+		59EEB53C2A059367008A8D16 /* indigo_ptp_canon.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBE42A02BED800135CCF /* indigo_ptp_canon.m */; };
+		59EEB53D2A059367008A8D16 /* indigo_ptp_sony.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBEA2A02BEEB00135CCF /* indigo_ptp_sony.m */; };
+		59EEB53E2A059367008A8D16 /* indigo_ptp_ica.h in Headers */ = {isa = PBXBuildFile; fileRef = 5937CBF32A02C25900135CCF /* indigo_ptp_ica.h */; };
+		59EEB53F2A059367008A8D16 /* indigo_ccd_ptp.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DA71CF02A0255A900CFA533 /* indigo_ccd_ptp.m */; };
+		59EEB5402A059367008A8D16 /* indigo_ptp_nikon.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBE72A02BEE100135CCF /* indigo_ptp_nikon.m */; };
+		59EEB5412A059367008A8D16 /* indigo_ptp_fuji.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBED2A02BEF700135CCF /* indigo_ptp_fuji.m */; };
+		59EEB5422A059368008A8D16 /* indigo_ptp.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBE12A02BE9800135CCF /* indigo_ptp.m */; };
+		59EEB5432A059368008A8D16 /* indigo_ptp_canon.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBE42A02BED800135CCF /* indigo_ptp_canon.m */; };
+		59EEB5442A059368008A8D16 /* indigo_ptp_sony.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBEA2A02BEEB00135CCF /* indigo_ptp_sony.m */; };
+		59EEB5452A059368008A8D16 /* indigo_ptp_ica.h in Headers */ = {isa = PBXBuildFile; fileRef = 5937CBF32A02C25900135CCF /* indigo_ptp_ica.h */; };
+		59EEB5462A059368008A8D16 /* indigo_ccd_ptp.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DA71CF02A0255A900CFA533 /* indigo_ccd_ptp.m */; };
+		59EEB5472A059368008A8D16 /* indigo_ptp_nikon.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBE72A02BEE100135CCF /* indigo_ptp_nikon.m */; };
+		59EEB5482A059368008A8D16 /* indigo_ptp_fuji.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBED2A02BEF700135CCF /* indigo_ptp_fuji.m */; };
 		59EF8BC924683B2A009D75C5 /* indigo_dome_baader.c in Sources */ = {isa = PBXBuildFile; fileRef = 59EF8BC024683B10009D75C5 /* indigo_dome_baader.c */; };
 		59EFE8A62363483000ED5337 /* indigo_focuser_focusdreampro.c in Sources */ = {isa = PBXBuildFile; fileRef = 59EFE8A22363481D00ED5337 /* indigo_focuser_focusdreampro.c */; };
 		59F0FE2D2083EA4F001B34E9 /* indigo_ccd_simulator_data.c in Sources */ = {isa = PBXBuildFile; fileRef = 59F0FE2C2083EA47001B34E9 /* indigo_ccd_simulator_data.c */; };
@@ -12846,19 +12848,18 @@
 				9D586C3D22FB0C34002D382E /* README.md */,
 				5937CBF72A02E70200135CCF /* Makefile */,
 				9D586C3E22FB0D43002D382E /* indigo_ccd_ptp.h */,
-				9D586C3F22FB0D43002D382E /* indigo_ccd_ptp.c */,
 				59FA0B1C22FB400900A15D19 /* indigo_ptp.h */,
-				9D586C4422FC6265002D382E /* indigo_ptp.c */,
 				59FA0B1D22FCACC600A15D19 /* indigo_ptp_canon.h */,
-				59FA0B1E22FCACC600A15D19 /* indigo_ptp_canon.c */,
 				59D6718D22FDBB7500D08A2A /* indigo_ptp_nikon.h */,
-				59D6718C22FDBB7500D08A2A /* indigo_ptp_nikon.c */,
 				59D6719122FDBB8D00D08A2A /* indigo_ptp_sony.h */,
-				59D6719022FDBB8D00D08A2A /* indigo_ptp_sony.c */,
 				59C3BB10255077E8000720B4 /* indigo_ptp_fuji.h */,
-				59C3BB0F255077E8000720B4 /* indigo_ptp_fuji.c */,
 				595E9FC0233E6666006E01D3 /* ptp_camera_model.h */,
-				59C3BB0E255077E8000720B4 /* indigo_ccd_ptp_main.c */,
+				9D586C3F22FB0D43002D382E /* indigo_ccd_ptp.c */,
+				9D586C4422FC6265002D382E /* indigo_ptp.c */,
+				59FA0B1E22FCACC600A15D19 /* indigo_ptp_canon.c */,
+				59D6718C22FDBB7500D08A2A /* indigo_ptp_nikon.c */,
+				59D6719022FDBB8D00D08A2A /* indigo_ptp_sony.c */,
+				59C3BB0F255077E8000720B4 /* indigo_ptp_fuji.c */,
 				5937CBF32A02C25900135CCF /* indigo_ptp_ica.h */,
 				9DA71CF02A0255A900CFA533 /* indigo_ccd_ptp.m */,
 				5937CBE12A02BE9800135CCF /* indigo_ptp.m */,
@@ -12866,6 +12867,7 @@
 				5937CBE72A02BEE100135CCF /* indigo_ptp_nikon.m */,
 				5937CBEA2A02BEEB00135CCF /* indigo_ptp_sony.m */,
 				5937CBED2A02BEF700135CCF /* indigo_ptp_fuji.m */,
+				59C3BB0E255077E8000720B4 /* indigo_ccd_ptp_main.c */,
 			);
 			path = ccd_ptp;
 			sourceTree = "<group>";
@@ -13845,6 +13847,7 @@
 				598A1C7C259BA94A00C0B34C /* indigo_agent_guider.h in Headers */,
 				598A1C7D259BA94A00C0B34C /* DDHidQueue.h in Headers */,
 				598A1C7E259BA94A00C0B34C /* NSDictionary+DDHidExtras.h in Headers */,
+				59EEB5452A059368008A8D16 /* indigo_ptp_ica.h in Headers */,
 				59118C322996EB440004BEC8 /* indigo_ccd_ogma.h in Headers */,
 				59111D0F285F53D100E57194 /* indigocat_solar_system.h in Headers */,
 				598A1C80259BA94A00C0B34C /* gxccd.h in Headers */,
@@ -13931,6 +13934,7 @@
 				59D9682F21A2FE5D0069A64C /* EFW_filter.h in Headers */,
 				5979C88A254A9EED005395BE /* indigo_wheel_qhy.h in Headers */,
 				591CD0CC298042C0003243AE /* starshootg.h in Headers */,
+				59EEB53E2A059367008A8D16 /* indigo_ptp_ica.h in Headers */,
 				9D4D64B220A9D947008ECE4B /* indigo_guider_eqmac.h in Headers */,
 				595F291C211E211100380EF4 /* DDHidElement.h in Headers */,
 				595F2924211E211200380EF4 /* DDHidDevice.h in Headers */,
@@ -14336,7 +14340,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				599FC6962A0438710030ED16 /* indigo_ptp_canon.m in Sources */,
 				59111CF2285F504200E57194 /* indigocat_earth.c in Sources */,
 				598A1B54259BA94A00C0B34C /* libuvc_misc.c in Sources */,
 				598A1B55259BA94A00C0B34C /* indigo_ccd_qhy.cpp in Sources */,
@@ -14363,10 +14366,10 @@
 				598A1B67259BA94A00C0B34C /* libuvc_stream.c in Sources */,
 				59A413392971E54C00F0A80B /* Makefile.inc in Sources */,
 				9DA71D0C2A029BE600CFA533 /* indigo_ica_ptp.m in Sources */,
+				59EEB5472A059368008A8D16 /* indigo_ptp_nikon.m in Sources */,
 				9DA71D142A029BE600CFA533 /* indigo_ica_ptp_sony.m in Sources */,
 				598A1B68259BA94A00C0B34C /* indigo_mount_ioptron.c in Sources */,
 				598A1B69259BA94A00C0B34C /* indigo_gps_nmea.c in Sources */,
-				599FC6992A0438710030ED16 /* indigo_ptp_nikon.m in Sources */,
 				593A8F11285F616F00F6CF1C /* indigocat_precession.c in Sources */,
 				598A1B6A259BA94A00C0B34C /* indigo_mount_temma.c in Sources */,
 				598A1B6C259BA94A00C0B34C /* DDHidElement.m in Sources */,
@@ -14394,7 +14397,6 @@
 				597BD19E2606974900239274 /* alpaca_lightbox.c in Sources */,
 				598A1B7E259BA94A00C0B34C /* indigo_gps_gpsd.c in Sources */,
 				598A1B7F259BA94A00C0B34C /* indigo_focuser_asi.c in Sources */,
-				599FC6952A0438710030ED16 /* indigo_ptp.m in Sources */,
 				597BD16426013CDD00239274 /* indigo_agent_alpaca.c in Sources */,
 				598A1B80259BA94A00C0B34C /* indigo_agent_guider.c in Sources */,
 				598A1B81259BA94A00C0B34C /* indigo_aux_usbdp.c in Sources */,
@@ -14451,12 +14453,14 @@
 				598A1BA9259BA94A00C0B34C /* indigo_aux_sqm.c in Sources */,
 				59D8BBD7260E628B00B904EE /* alpaca_ccd.c in Sources */,
 				598A1BAA259BA94A00C0B34C /* indigo_wheel_manual.c in Sources */,
+				59EEB5432A059368008A8D16 /* indigo_ptp_canon.m in Sources */,
 				59111CF3285F504200E57194 /* indigocat_mars.c in Sources */,
 				59F6BB42261CA65800DA9BE1 /* alpaca_switch.c in Sources */,
 				598A1BAB259BA94A00C0B34C /* indigo_aux_dragonfly.c in Sources */,
 				598A1BAC259BA94A00C0B34C /* DDHidKeyboard.m in Sources */,
 				598A1BAD259BA94A00C0B34C /* indigo_wheel_optec.c in Sources */,
 				598A1BAE259BA94A00C0B34C /* indigo_aux_arteskyflat.c in Sources */,
+				59EEB5462A059368008A8D16 /* indigo_ccd_ptp.m in Sources */,
 				598A1BAF259BA94A00C0B34C /* indigo_focuser_mjkzz_bt.m in Sources */,
 				598A1BB0259BA94A00C0B34C /* indigo_filter.c in Sources */,
 				9DA71D112A029BE600CFA533 /* indigo_ica_ptp_canon.m in Sources */,
@@ -14483,12 +14487,13 @@
 				598A1BBE259BA94A00C0B34C /* indigo_guider_gpusb.c in Sources */,
 				598A1BBF259BA94A00C0B34C /* indigo_driver_xml.c in Sources */,
 				59111CE9285F504200E57194 /* indigocat_pluto.c in Sources */,
+				59EEB5442A059368008A8D16 /* indigo_ptp_sony.m in Sources */,
 				598A1BC0259BA94A00C0B34C /* indigo_agent_scripting.c in Sources */,
 				598A1BC2259BA94A00C0B34C /* nexstar_pec.c in Sources */,
+				59EEB5422A059368008A8D16 /* indigo_ptp.m in Sources */,
 				59111CF0285F504200E57194 /* indigocat_nutation.c in Sources */,
 				59111CE8285F504200E57194 /* indigocat_neptune.c in Sources */,
 				598A1BC3259BA94A00C0B34C /* indigo_wheel_driver.c in Sources */,
-				599FC6972A0438710030ED16 /* indigo_ptp_fuji.m in Sources */,
 				598A1BC4259BA94A00C0B34C /* indigo_focuser_wemacro_bt.m in Sources */,
 				59BBED28278493E400BA9CD6 /* indigo_agent_astap.c in Sources */,
 				9D62F70228FEAF62006599FF /* indigo_agent_config.c in Sources */,
@@ -14504,9 +14509,7 @@
 				598A1BCE259BA94A00C0B34C /* indigo_focuser_dmfc.c in Sources */,
 				598A1BCF259BA94A00C0B34C /* indigo_mount_driver.c in Sources */,
 				598A1BD1259BA94A00C0B34C /* indigo_json.c in Sources */,
-				599FC6982A0438710030ED16 /* indigo_ccd_ptp.m in Sources */,
 				598A1BD2259BA94A00C0B34C /* indigo_server_tcp.c in Sources */,
-				599FC6942A0438710030ED16 /* indigo_ptp_sony.m in Sources */,
 				598A1BD3259BA94A00C0B34C /* indigo_mount_synscan_protocol.c in Sources */,
 				598A1BD4259BA94A00C0B34C /* indigo_agent_auxiliary.c in Sources */,
 				598A1BD5259BA94A00C0B34C /* indigo_agent.c in Sources */,
@@ -14522,6 +14525,7 @@
 				598A1BDC259BA94A00C0B34C /* indigo_focuser_optec.c in Sources */,
 				598A1BDD259BA94A00C0B34C /* indigo_focuser_lakeside.c in Sources */,
 				59D2B9E8294A2B22002F0F90 /* indigo_ccd_asi.c in Sources */,
+				59EEB5482A059368008A8D16 /* indigo_ptp_fuji.m in Sources */,
 				598A1BDE259BA94A00C0B34C /* indigo_dome_nexdome3.c in Sources */,
 				598A1BDF259BA94A00C0B34C /* indigo_wheel_xagyl.c in Sources */,
 				591CD11329806D42003243AE /* indigo_ccd_mallin.c in Sources */,
@@ -14588,6 +14592,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				59EEB53C2A059367008A8D16 /* indigo_ptp_canon.m in Sources */,
 				59D29A1B2841469D00D5E7F7 /* indigo_mount_starbook.c in Sources */,
 				9D73E61B21FF37F9003CEC15 /* libuvc_misc.c in Sources */,
 				595567CE24B88F5B00DF303D /* indigo_ccd_qhy.cpp in Sources */,
@@ -14617,6 +14622,7 @@
 				597DFE242804A880009E37CB /* indigo_rotator_optec.c in Sources */,
 				9D73E61E21FF37F9003CEC15 /* libuvc_stream.c in Sources */,
 				9DAD523121246EB5002FCC79 /* indigo_mount_ioptron.c in Sources */,
+				59EEB5402A059367008A8D16 /* indigo_ptp_nikon.m in Sources */,
 				59DD69C91FC1CF8D00AEF0DF /* indigo_gps_nmea.c in Sources */,
 				590B59D41F7858FE00086FD2 /* indigo_mount_temma.c in Sources */,
 				595F292E211E211200380EF4 /* DDHidElement.m in Sources */,
@@ -14644,6 +14650,7 @@
 				597BD1CF260CE2A800239274 /* alpaca_rotator.c in Sources */,
 				599C9A4C1DA022E3008BBCC1 /* indigo_driver.c in Sources */,
 				597BD19D2606974900239274 /* alpaca_lightbox.c in Sources */,
+				59EEB53B2A059367008A8D16 /* indigo_ptp.m in Sources */,
 				9D35EA2B23CDB27D00B6A41F /* indigo_gps_gpsd.c in Sources */,
 				591CCFAC2980396B003243AE /* indigo_ccd_omegonpro.c in Sources */,
 				59111D00285F504300E57194 /* indigocat_dynamical_time.c in Sources */,
@@ -14665,7 +14672,6 @@
 				590BF1B421EBCF7500C24DBA /* indigo_ao_sx.c in Sources */,
 				598FE2752614F91A00E0DA21 /* indigo_dome_talon6ror.c in Sources */,
 				597BD19326067B0100239274 /* alpaca_focuser.c in Sources */,
-				599FC6922A0438700030ED16 /* indigo_ccd_ptp.m in Sources */,
 				59C8E7FB1DBBDF7A00AA3F0A /* indigo_wheel_sx.c in Sources */,
 				595F2923211E211200380EF4 /* NSXReturnThrowError.m in Sources */,
 				59111CFA285F504300E57194 /* indigocat_venus.c in Sources */,
@@ -14713,7 +14719,6 @@
 				59B81EC523376FE000DFA81B /* indigo_aux_arteskyflat.c in Sources */,
 				59111CFD285F504300E57194 /* indigocat_jupiter.c in Sources */,
 				9D61B9DF216DE636000DE7E8 /* indigo_focuser_mjkzz_bt.m in Sources */,
-				599FC6912A0438700030ED16 /* indigo_ptp_fuji.m in Sources */,
 				593A3580219DBE5E00EDF481 /* indigo_filter.c in Sources */,
 				9D9EA6B21DBFA30600E11841 /* indigo_ccd_driver.c in Sources */,
 				599C9A501DA022E3008BBCC1 /* indigo_xml.c in Sources */,
@@ -14733,13 +14738,12 @@
 				594122A11FD2DE7800D792FF /* indigo_dome_azimuth.c in Sources */,
 				595567D824BA00DA00DF303D /* indigo_mount_pmc8_main.c in Sources */,
 				59D62CDB1E731B62004DDD9C /* indigo_focuser_usbv3.c in Sources */,
+				59EEB5412A059367008A8D16 /* indigo_ptp_fuji.m in Sources */,
 				59FE347C2187B7DD004FB5D4 /* indigo_guider_gpusb.c in Sources */,
 				599C9A511DA022E3008BBCC1 /* indigo_driver_xml.c in Sources */,
 				5910D9B7258008190015D915 /* indigo_agent_scripting.c in Sources */,
 				59111D02285F504300E57194 /* indigocat_mars.c in Sources */,
 				59C76F11237872520091B966 /* nexstar_pec.c in Sources */,
-				599FC68F2A0438700030ED16 /* indigo_ptp.m in Sources */,
-				599FC68E2A0438700030ED16 /* indigo_ptp_sony.m in Sources */,
 				9D9EA6B61DBFA30600E11841 /* indigo_wheel_driver.c in Sources */,
 				59463C1B20DE6781004950F2 /* indigo_focuser_wemacro_bt.m in Sources */,
 				59B51350297066040075C8A1 /* indigo_wheel_indigo.c in Sources */,
@@ -14757,8 +14761,10 @@
 				5955CB7D2684E93E00685071 /* indigo_aux_astromechanics.c in Sources */,
 				599C9A521DA022E3008BBCC1 /* indigo_client_xml.c in Sources */,
 				59D8BBC5260E624600B904EE /* alpaca_dome.c in Sources */,
+				59EEB53F2A059367008A8D16 /* indigo_ccd_ptp.m in Sources */,
 				59111CF6285F504300E57194 /* indigocat_moon.c in Sources */,
 				9DFE1869213586B100149BDE /* indigo_focuser_dmfc.c in Sources */,
+				59EEB53D2A059367008A8D16 /* indigo_ptp_sony.m in Sources */,
 				5913653928CFB42000ABB99B /* indigo_md5.c in Sources */,
 				59540AD626D00CCF000C2A1B /* indigo_aux_geoptikflat.c in Sources */,
 				59D707691DC527B800DEF566 /* indigo_mount_driver.c in Sources */,
@@ -14796,7 +14802,6 @@
 				595F291A211E211100380EF4 /* DDHidEvent.m in Sources */,
 				9D4D64B320A9D947008ECE4B /* indigo_guider_eqmac.c in Sources */,
 				5911F7B31F02E1390053F3CA /* indigo_ccd_dsi.c in Sources */,
-				599FC6932A0438700030ED16 /* indigo_ptp_nikon.m in Sources */,
 				9DAC59D31DC0A8AD00AE410D /* indigo_focuser_driver.c in Sources */,
 				9DB918081DFEA42E00678721 /* indigo_io.c in Sources */,
 				9DAD522621246C18002FCC79 /* indigo_mount_synscan_driver.c in Sources */,
@@ -14812,7 +14817,6 @@
 				5979C862254710B0005395BE /* indigo_tiff.c in Sources */,
 				9D48B7B6215E5B6100CF757E /* indigo_ccd_touptek.c in Sources */,
 				9DE0E7C222C6465500289234 /* indigo_focuser_dsd.c in Sources */,
-				599FC6902A0438700030ED16 /* indigo_ptp_canon.m in Sources */,
 				59B636B020A74CD400EF2D52 /* indigo_usb_utils.c in Sources */,
 				595B88EC242CFEA2008CA4E2 /* indigo_token.c in Sources */,
 				59F1AD1223FB15B300008F02 /* indigo_focuser_lunatico.c in Sources */,

--- a/indigo.xcodeproj/project.pbxproj
+++ b/indigo.xcodeproj/project.pbxproj
@@ -125,6 +125,18 @@
 		592E79192168E06B00E856F3 /* indigo_focuser_mjkzz.c in Sources */ = {isa = PBXBuildFile; fileRef = 592E79162168DD7A00E856F3 /* indigo_focuser_mjkzz.c */; };
 		5931B7282535FA8A008F74A1 /* libindigo.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 5931B7272535FA8A008F74A1 /* libindigo.dylib */; };
 		593287A62409AD1000ED61C0 /* indigo_rotator_lunatico.c in Sources */ = {isa = PBXBuildFile; fileRef = 593287A22409ACC700ED61C0 /* indigo_rotator_lunatico.c */; };
+		5937CBE22A02BE9800135CCF /* indigo_ptp.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBE12A02BE9800135CCF /* indigo_ptp.m */; };
+		5937CBE32A02BE9800135CCF /* indigo_ptp.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBE12A02BE9800135CCF /* indigo_ptp.m */; };
+		5937CBE52A02BED800135CCF /* indigo_ptp_canon.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBE42A02BED800135CCF /* indigo_ptp_canon.m */; };
+		5937CBE62A02BED800135CCF /* indigo_ptp_canon.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBE42A02BED800135CCF /* indigo_ptp_canon.m */; };
+		5937CBE82A02BEE100135CCF /* indigo_ptp_nikon.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBE72A02BEE100135CCF /* indigo_ptp_nikon.m */; };
+		5937CBE92A02BEE100135CCF /* indigo_ptp_nikon.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBE72A02BEE100135CCF /* indigo_ptp_nikon.m */; };
+		5937CBEB2A02BEEB00135CCF /* indigo_ptp_sony.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBEA2A02BEEB00135CCF /* indigo_ptp_sony.m */; };
+		5937CBEC2A02BEEB00135CCF /* indigo_ptp_sony.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBEA2A02BEEB00135CCF /* indigo_ptp_sony.m */; };
+		5937CBEE2A02BEF700135CCF /* indigo_ptp_fuji.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBED2A02BEF700135CCF /* indigo_ptp_fuji.m */; };
+		5937CBEF2A02BEF700135CCF /* indigo_ptp_fuji.m in Sources */ = {isa = PBXBuildFile; fileRef = 5937CBED2A02BEF700135CCF /* indigo_ptp_fuji.m */; };
+		5937CBF42A02C25900135CCF /* indigo_ptp_ica.h in Headers */ = {isa = PBXBuildFile; fileRef = 5937CBF32A02C25900135CCF /* indigo_ptp_ica.h */; };
+		5937CBF52A02C25900135CCF /* indigo_ptp_ica.h in Headers */ = {isa = PBXBuildFile; fileRef = 5937CBF32A02C25900135CCF /* indigo_ptp_ica.h */; };
 		59399D902177D67C002886CA /* indigo_focuser_optec.c in Sources */ = {isa = PBXBuildFile; fileRef = 59399D892177D316002886CA /* indigo_focuser_optec.c */; };
 		593A357E219DBAD500EDF481 /* indigo_filter.h in Headers */ = {isa = PBXBuildFile; fileRef = 593A357A219DB4BA00EDF481 /* indigo_filter.h */; };
 		593A3580219DBE5E00EDF481 /* indigo_filter.c in Sources */ = {isa = PBXBuildFile; fileRef = 593A357B219DB4BA00EDF481 /* indigo_filter.c */; };
@@ -278,11 +290,9 @@
 		598A1B57259BA94A00C0B34C /* indigo_ccd_simulator.c in Sources */ = {isa = PBXBuildFile; fileRef = 59D381AB1D95996100E87393 /* indigo_ccd_simulator.c */; };
 		598A1B58259BA94A00C0B34C /* indigo_dome_baader.c in Sources */ = {isa = PBXBuildFile; fileRef = 59EF8BC024683B10009D75C5 /* indigo_dome_baader.c */; };
 		598A1B59259BA94A00C0B34C /* indigo_dome_dragonfly.c in Sources */ = {isa = PBXBuildFile; fileRef = 591F328624211EB000D1D64B /* indigo_dome_dragonfly.c */; };
-		598A1B5A259BA94A00C0B34C /* indigo_ptp_canon.c in Sources */ = {isa = PBXBuildFile; fileRef = 59FA0B1E22FCACC600A15D19 /* indigo_ptp_canon.c */; };
 		598A1B5B259BA94A00C0B34C /* indigo_raw_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 5911B6C922630FE900D6B9EC /* indigo_raw_utils.c */; };
 		598A1B5C259BA94A00C0B34C /* indigo_aux_dsusb.c in Sources */ = {isa = PBXBuildFile; fileRef = 59FE34622187B2F7004FB5D4 /* indigo_aux_dsusb.c */; };
 		598A1B5D259BA94A00C0B34C /* indigo_focuser_steeldrive2.c in Sources */ = {isa = PBXBuildFile; fileRef = 59A242F322A5B45E001C38F8 /* indigo_focuser_steeldrive2.c */; };
-		598A1B5E259BA94A00C0B34C /* indigo_ptp_fuji.c in Sources */ = {isa = PBXBuildFile; fileRef = 59C3BB0F255077E8000720B4 /* indigo_ptp_fuji.c */; };
 		598A1B5F259BA94A00C0B34C /* indigo_agent_alignment.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D85FAE321E38E3900ECDF82 /* indigo_agent_alignment.c */; };
 		598A1B60259BA94A00C0B34C /* indigo_wheel_trutek.c in Sources */ = {isa = PBXBuildFile; fileRef = 9DAD524A2126E88B002FCC79 /* indigo_wheel_trutek.c */; };
 		598A1B61259BA94A00C0B34C /* indigo_driver_json.c in Sources */ = {isa = PBXBuildFile; fileRef = 599A63AE1DEA2F4700ABC827 /* indigo_driver_json.c */; };
@@ -290,12 +300,10 @@
 		598A1B63259BA94A00C0B34C /* indigo_ccd_sx.c in Sources */ = {isa = PBXBuildFile; fileRef = 5999FB661DA40B380084BBF8 /* indigo_ccd_sx.c */; };
 		598A1B64259BA94A00C0B34C /* nex_open.c in Sources */ = {isa = PBXBuildFile; fileRef = 598C582F21A75B1A001CA8C0 /* nex_open.c */; };
 		598A1B65259BA94A00C0B34C /* indigo_mount_simulator.c in Sources */ = {isa = PBXBuildFile; fileRef = 59D7076D1DC52C3E00DEF566 /* indigo_mount_simulator.c */; };
-		598A1B66259BA94A00C0B34C /* indigo_ptp_sony.c in Sources */ = {isa = PBXBuildFile; fileRef = 59D6719022FDBB8D00D08A2A /* indigo_ptp_sony.c */; };
 		598A1B67259BA94A00C0B34C /* libuvc_stream.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D73E61521FF37F9003CEC15 /* libuvc_stream.c */; };
 		598A1B68259BA94A00C0B34C /* indigo_mount_ioptron.c in Sources */ = {isa = PBXBuildFile; fileRef = 9DAD522E21246EB5002FCC79 /* indigo_mount_ioptron.c */; };
 		598A1B69259BA94A00C0B34C /* indigo_gps_nmea.c in Sources */ = {isa = PBXBuildFile; fileRef = 59DD69C51FC1CF8D00AEF0DF /* indigo_gps_nmea.c */; };
 		598A1B6A259BA94A00C0B34C /* indigo_mount_temma.c in Sources */ = {isa = PBXBuildFile; fileRef = 590B59D11F78544000086FD2 /* indigo_mount_temma.c */; };
-		598A1B6B259BA94A00C0B34C /* indigo_ptp_nikon.c in Sources */ = {isa = PBXBuildFile; fileRef = 59D6718C22FDBB7500D08A2A /* indigo_ptp_nikon.c */; };
 		598A1B6C259BA94A00C0B34C /* DDHidElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 595F2911211E211100380EF4 /* DDHidElement.m */; };
 		598A1B6D259BA94A00C0B34C /* indigo_focuser_moonlite.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D4F4741215A4440006110FD /* indigo_focuser_moonlite.c */; };
 		598A1B6E259BA94A00C0B34C /* indigo_focuser_efa.c in Sources */ = {isa = PBXBuildFile; fileRef = 59413564232404D700ED5FF4 /* indigo_focuser_efa.c */; };
@@ -700,7 +708,6 @@
 		59BBED28278493E400BA9CD6 /* indigo_agent_astap.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BBED24278493E400BA9CD6 /* indigo_agent_astap.c */; };
 		59C3BAFC254DE8AD000720B4 /* indigo_ser.h in Headers */ = {isa = PBXBuildFile; fileRef = 59C3BAFA254DE8AD000720B4 /* indigo_ser.h */; };
 		59C3BAFD254DE8AD000720B4 /* indigo_ser.c in Sources */ = {isa = PBXBuildFile; fileRef = 59C3BAFB254DE8AD000720B4 /* indigo_ser.c */; };
-		59C3BB12255077E9000720B4 /* indigo_ptp_fuji.c in Sources */ = {isa = PBXBuildFile; fileRef = 59C3BB0F255077E8000720B4 /* indigo_ptp_fuji.c */; };
 		59C3BB13255077E9000720B4 /* indigo_ptp_fuji.h in Headers */ = {isa = PBXBuildFile; fileRef = 59C3BB10255077E8000720B4 /* indigo_ptp_fuji.h */; };
 		59C4C88420CEF107007EE330 /* indigo_focuser_wemacro.h in Headers */ = {isa = PBXBuildFile; fileRef = 59C4C88020CEF107007EE330 /* indigo_focuser_wemacro.h */; };
 		59C565072464A14C00344C0C /* indigo_aux_mgbox.c in Sources */ = {isa = PBXBuildFile; fileRef = 59C565012464A13A00344C0C /* indigo_aux_mgbox.c */; };
@@ -733,9 +740,7 @@
 		59D2B9FA294A332E002F0F90 /* indigo_mount_asi.h in Headers */ = {isa = PBXBuildFile; fileRef = 59D2B9F2294A332E002F0F90 /* indigo_mount_asi.h */; };
 		59D2B9FB294A332E002F0F90 /* indigo_mount_asi.h in Headers */ = {isa = PBXBuildFile; fileRef = 59D2B9F2294A332E002F0F90 /* indigo_mount_asi.h */; };
 		59D62CDB1E731B62004DDD9C /* indigo_focuser_usbv3.c in Sources */ = {isa = PBXBuildFile; fileRef = 59D62CD81E731490004DDD9C /* indigo_focuser_usbv3.c */; };
-		59D6718E22FDBB7500D08A2A /* indigo_ptp_nikon.c in Sources */ = {isa = PBXBuildFile; fileRef = 59D6718C22FDBB7500D08A2A /* indigo_ptp_nikon.c */; };
 		59D6718F22FDBB7500D08A2A /* indigo_ptp_nikon.h in Headers */ = {isa = PBXBuildFile; fileRef = 59D6718D22FDBB7500D08A2A /* indigo_ptp_nikon.h */; };
-		59D6719222FDBB8E00D08A2A /* indigo_ptp_sony.c in Sources */ = {isa = PBXBuildFile; fileRef = 59D6719022FDBB8D00D08A2A /* indigo_ptp_sony.c */; };
 		59D6719322FDBB8E00D08A2A /* indigo_ptp_sony.h in Headers */ = {isa = PBXBuildFile; fileRef = 59D6719122FDBB8D00D08A2A /* indigo_ptp_sony.h */; };
 		59D707691DC527B800DEF566 /* indigo_mount_driver.c in Sources */ = {isa = PBXBuildFile; fileRef = 59D707671DC527B800DEF566 /* indigo_mount_driver.c */; };
 		59D7076A1DC527B800DEF566 /* indigo_mount_driver.h in Headers */ = {isa = PBXBuildFile; fileRef = 59D707681DC527B800DEF566 /* indigo_mount_driver.h */; };
@@ -773,7 +778,6 @@
 		59F871BD26A87162007DF91C /* indigo_ccd_mi.c in Sources */ = {isa = PBXBuildFile; fileRef = 59FC2EB6210CA76100730343 /* indigo_ccd_mi.c */; };
 		59F871BF26A871B6007DF91C /* libgxccd.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 59A52D5B21A3360B000B6F27 /* libgxccd.a */; };
 		59FA0B1F22FCACC700A15D19 /* indigo_ptp_canon.h in Headers */ = {isa = PBXBuildFile; fileRef = 59FA0B1D22FCACC600A15D19 /* indigo_ptp_canon.h */; };
-		59FA0B2022FCACC700A15D19 /* indigo_ptp_canon.c in Sources */ = {isa = PBXBuildFile; fileRef = 59FA0B1E22FCACC600A15D19 /* indigo_ptp_canon.c */; };
 		59FC2EBC210CA76200730343 /* indigo_ccd_mi.h in Headers */ = {isa = PBXBuildFile; fileRef = 59FC2EB7210CA76100730343 /* indigo_ccd_mi.h */; };
 		59FE34652187B2F8004FB5D4 /* indigo_aux_dsusb.c in Sources */ = {isa = PBXBuildFile; fileRef = 59FE34622187B2F7004FB5D4 /* indigo_aux_dsusb.c */; };
 		59FE34662187B2F8004FB5D4 /* indigo_aux_dsusb.h in Headers */ = {isa = PBXBuildFile; fileRef = 59FE34632187B2F7004FB5D4 /* indigo_aux_dsusb.h */; };
@@ -841,8 +845,6 @@
 		9DA451CF21908CBC00818B58 /* indigo_agent_imager.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DA451CD21908CBC00818B58 /* indigo_agent_imager.h */; };
 		9DA71CF12A0255A900CFA533 /* indigo_ccd_ptp.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DA71CF02A0255A900CFA533 /* indigo_ccd_ptp.m */; };
 		9DA71CF22A0255A900CFA533 /* indigo_ccd_ptp.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DA71CF02A0255A900CFA533 /* indigo_ccd_ptp.m */; };
-		9DA71CF32A025A0A00CFA533 /* indigo_ptp.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D586C4422FC6265002D382E /* indigo_ptp.c */; };
-		9DA71CF42A025A0B00CFA533 /* indigo_ptp.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D586C4422FC6265002D382E /* indigo_ptp.c */; };
 		9DA71D012A029BE500CFA533 /* indigo_ccd_ica.m in Sources */ = {isa = PBXBuildFile; fileRef = 59C499E21EFADFE000E750AA /* indigo_ccd_ica.m */; };
 		9DA71D022A029BE500CFA533 /* indigo_ica_ptp.m in Sources */ = {isa = PBXBuildFile; fileRef = 59C499E41EFADFE000E750AA /* indigo_ica_ptp.m */; };
 		9DA71D032A029BE500CFA533 /* indigo_ica_ptp_canon.h in Headers */ = {isa = PBXBuildFile; fileRef = 59E38B4F1F1577A000187839 /* indigo_ica_ptp_canon.h */; };
@@ -1213,6 +1215,12 @@
 		5932DD3524B20C1400B90A6A /* README.arm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README.arm; sourceTree = "<group>"; };
 		5932DD3624B20C8D00B90A6A /* ASICamera2 Software Development Kit.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; name = "ASICamera2 Software Development Kit.pdf"; path = "doc/ASICamera2 Software Development Kit.pdf"; sourceTree = "<group>"; };
 		5936A993299C0D1F00C3095A /* uncrustify.cfg */ = {isa = PBXFileReference; lastKnownFileType = text; path = uncrustify.cfg; sourceTree = "<group>"; };
+		5937CBE12A02BE9800135CCF /* indigo_ptp.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = indigo_ptp.m; sourceTree = "<group>"; };
+		5937CBE42A02BED800135CCF /* indigo_ptp_canon.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = indigo_ptp_canon.m; sourceTree = "<group>"; };
+		5937CBE72A02BEE100135CCF /* indigo_ptp_nikon.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = indigo_ptp_nikon.m; sourceTree = "<group>"; };
+		5937CBEA2A02BEEB00135CCF /* indigo_ptp_sony.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = indigo_ptp_sony.m; sourceTree = "<group>"; };
+		5937CBED2A02BEF700135CCF /* indigo_ptp_fuji.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = indigo_ptp_fuji.m; sourceTree = "<group>"; };
+		5937CBF32A02C25900135CCF /* indigo_ptp_ica.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = indigo_ptp_ica.h; sourceTree = "<group>"; };
 		59399D892177D316002886CA /* indigo_focuser_optec.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = indigo_focuser_optec.c; sourceTree = "<group>"; };
 		59399D8A2177D316002886CA /* indigo_focuser_optec_main.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = indigo_focuser_optec_main.c; sourceTree = "<group>"; };
 		59399D8B2177D316002886CA /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -12837,7 +12845,6 @@
 				9D586C3D22FB0C34002D382E /* README.md */,
 				9D586C3E22FB0D43002D382E /* indigo_ccd_ptp.h */,
 				9D586C3F22FB0D43002D382E /* indigo_ccd_ptp.c */,
-				9DA71CF02A0255A900CFA533 /* indigo_ccd_ptp.m */,
 				59FA0B1C22FB400900A15D19 /* indigo_ptp.h */,
 				9D586C4422FC6265002D382E /* indigo_ptp.c */,
 				59FA0B1D22FCACC600A15D19 /* indigo_ptp_canon.h */,
@@ -12850,6 +12857,13 @@
 				59C3BB0F255077E8000720B4 /* indigo_ptp_fuji.c */,
 				595E9FC0233E6666006E01D3 /* ptp_camera_model.h */,
 				59C3BB0E255077E8000720B4 /* indigo_ccd_ptp_main.c */,
+				5937CBF32A02C25900135CCF /* indigo_ptp_ica.h */,
+				9DA71CF02A0255A900CFA533 /* indigo_ccd_ptp.m */,
+				5937CBE12A02BE9800135CCF /* indigo_ptp.m */,
+				5937CBE42A02BED800135CCF /* indigo_ptp_canon.m */,
+				5937CBE72A02BEE100135CCF /* indigo_ptp_nikon.m */,
+				5937CBEA2A02BEEB00135CCF /* indigo_ptp_sony.m */,
+				5937CBED2A02BEF700135CCF /* indigo_ptp_fuji.m */,
 			);
 			path = ccd_ptp;
 			sourceTree = "<group>";
@@ -13702,6 +13716,7 @@
 				59B8A8C827ADAD8400A27609 /* indigo_align.h in Headers */,
 				598A1C1B259BA94A00C0B34C /* libdsusb.h in Headers */,
 				591CD0CD298042C1003243AE /* starshootg.h in Headers */,
+				5937CBF52A02C25900135CCF /* indigo_ptp_ica.h in Headers */,
 				598A1C1C259BA94A00C0B34C /* duk_config.h in Headers */,
 				598A1C1D259BA94A00C0B34C /* DDHidUsageTables.h in Headers */,
 				598A1C1E259BA94A00C0B34C /* indigo_driver_json.h in Headers */,
@@ -14003,6 +14018,7 @@
 				5911B6DA22633DBE00D6B9EC /* indigo_agent_guider.h in Headers */,
 				595F2920211E211100380EF4 /* DDHidQueue.h in Headers */,
 				595F2919211E211100380EF4 /* NSDictionary+DDHidExtras.h in Headers */,
+				5937CBF42A02C25900135CCF /* indigo_ptp_ica.h in Headers */,
 				59A52D6521A33617000B6F27 /* gxccd.h in Headers */,
 				59D7076A1DC527B800DEF566 /* indigo_mount_driver.h in Headers */,
 				9DAD52472126BD99002FCC79 /* indigo_wheel_quantum.h in Headers */,
@@ -14318,6 +14334,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5937CBE62A02BED800135CCF /* indigo_ptp_canon.m in Sources */,
 				59111CF2285F504200E57194 /* indigocat_earth.c in Sources */,
 				598A1B54259BA94A00C0B34C /* libuvc_misc.c in Sources */,
 				598A1B55259BA94A00C0B34C /* indigo_ccd_qhy.cpp in Sources */,
@@ -14326,12 +14343,10 @@
 				598A1B57259BA94A00C0B34C /* indigo_ccd_simulator.c in Sources */,
 				598A1B58259BA94A00C0B34C /* indigo_dome_baader.c in Sources */,
 				598A1B59259BA94A00C0B34C /* indigo_dome_dragonfly.c in Sources */,
-				598A1B5A259BA94A00C0B34C /* indigo_ptp_canon.c in Sources */,
 				598A1B5B259BA94A00C0B34C /* indigo_raw_utils.c in Sources */,
 				59111CEE285F504200E57194 /* indigocat_jupiter.c in Sources */,
 				598A1B5C259BA94A00C0B34C /* indigo_aux_dsusb.c in Sources */,
 				598A1B5D259BA94A00C0B34C /* indigo_focuser_steeldrive2.c in Sources */,
-				598A1B5E259BA94A00C0B34C /* indigo_ptp_fuji.c in Sources */,
 				598A1B5F259BA94A00C0B34C /* indigo_agent_alignment.c in Sources */,
 				59B51351297066040075C8A1 /* indigo_wheel_indigo.c in Sources */,
 				598A1B60259BA94A00C0B34C /* indigo_wheel_trutek.c in Sources */,
@@ -14343,7 +14358,6 @@
 				598A1B64259BA94A00C0B34C /* nex_open.c in Sources */,
 				598A1B65259BA94A00C0B34C /* indigo_mount_simulator.c in Sources */,
 				9DD01BE8298A63A50044FB3B /* indigo_build.c in Sources */,
-				598A1B66259BA94A00C0B34C /* indigo_ptp_sony.c in Sources */,
 				598A1B67259BA94A00C0B34C /* libuvc_stream.c in Sources */,
 				59A413392971E54C00F0A80B /* Makefile.inc in Sources */,
 				9DA71D0C2A029BE600CFA533 /* indigo_ica_ptp.m in Sources */,
@@ -14352,7 +14366,6 @@
 				598A1B69259BA94A00C0B34C /* indigo_gps_nmea.c in Sources */,
 				593A8F11285F616F00F6CF1C /* indigocat_precession.c in Sources */,
 				598A1B6A259BA94A00C0B34C /* indigo_mount_temma.c in Sources */,
-				598A1B6B259BA94A00C0B34C /* indigo_ptp_nikon.c in Sources */,
 				598A1B6C259BA94A00C0B34C /* DDHidElement.m in Sources */,
 				598A1B6D259BA94A00C0B34C /* indigo_focuser_moonlite.c in Sources */,
 				59111CF4285F504200E57194 /* indigocat_uranus.c in Sources */,
@@ -14414,6 +14427,7 @@
 				598A1B9B259BA94A00C0B34C /* indigo_agent_lx200_server.c in Sources */,
 				598A1B9C259BA94A00C0B34C /* libdsi.c in Sources */,
 				598A1B9D259BA94A00C0B34C /* nexstar.c in Sources */,
+				5937CBE92A02BEE100135CCF /* indigo_ptp_nikon.m in Sources */,
 				9DA71D0B2A029BE600CFA533 /* indigo_ccd_ica.m in Sources */,
 				598A1B9E259BA94A00C0B34C /* DDHidAppleMikey.m in Sources */,
 				591CCFAD2980396B003243AE /* indigo_ccd_omegonpro.c in Sources */,
@@ -14438,6 +14452,7 @@
 				59111CF3285F504200E57194 /* indigocat_mars.c in Sources */,
 				59F6BB42261CA65800DA9BE1 /* alpaca_switch.c in Sources */,
 				598A1BAB259BA94A00C0B34C /* indigo_aux_dragonfly.c in Sources */,
+				5937CBE32A02BE9800135CCF /* indigo_ptp.m in Sources */,
 				598A1BAC259BA94A00C0B34C /* DDHidKeyboard.m in Sources */,
 				598A1BAD259BA94A00C0B34C /* indigo_wheel_optec.c in Sources */,
 				598A1BAE259BA94A00C0B34C /* indigo_aux_arteskyflat.c in Sources */,
@@ -14452,6 +14467,7 @@
 				598A1BB4259BA94A00C0B34C /* indigo_aux_rts.c in Sources */,
 				598A1BB5259BA94A00C0B34C /* duktape.c in Sources */,
 				598A1BB6259BA94A00C0B34C /* DDHidQueue.m in Sources */,
+				5937CBEC2A02BEEB00135CCF /* indigo_ptp_sony.m in Sources */,
 				598A1BB7259BA94A00C0B34C /* indigo_mount_rainbow.c in Sources */,
 				594EF31D2770FD58002D0EC8 /* indigo_align.c in Sources */,
 				598A1BB8259BA94A00C0B34C /* indigo_ccd_simulator_data.c in Sources */,
@@ -14503,6 +14519,7 @@
 				598A1BDC259BA94A00C0B34C /* indigo_focuser_optec.c in Sources */,
 				598A1BDD259BA94A00C0B34C /* indigo_focuser_lakeside.c in Sources */,
 				59D2B9E8294A2B22002F0F90 /* indigo_ccd_asi.c in Sources */,
+				5937CBEF2A02BEF700135CCF /* indigo_ptp_fuji.m in Sources */,
 				598A1BDE259BA94A00C0B34C /* indigo_dome_nexdome3.c in Sources */,
 				598A1BDF259BA94A00C0B34C /* indigo_wheel_xagyl.c in Sources */,
 				591CD11329806D42003243AE /* indigo_ccd_mallin.c in Sources */,
@@ -14531,7 +14548,6 @@
 				598A1BF1259BA94A00C0B34C /* DDHidAppleRemote.m in Sources */,
 				598A1BF2259BA94A00C0B34C /* indigo_aux_flipflat.c in Sources */,
 				597BD1B5260A597400239274 /* alpaca_guider.c in Sources */,
-				9DA71CF42A025A0B00CFA533 /* indigo_ptp.c in Sources */,
 				5995A8D925A9AC69003987F1 /* indigo_platesolver.c in Sources */,
 				59111CEA285F504200E57194 /* indigocat_sun.c in Sources */,
 				598A1BF3259BA94A00C0B34C /* indigo_system_ascol.c in Sources */,
@@ -14572,19 +14588,18 @@
 			files = (
 				59D29A1B2841469D00D5E7F7 /* indigo_mount_starbook.c in Sources */,
 				9D73E61B21FF37F9003CEC15 /* libuvc_misc.c in Sources */,
+				5937CBE22A02BE9800135CCF /* indigo_ptp.m in Sources */,
 				595567CE24B88F5B00DF303D /* indigo_ccd_qhy.cpp in Sources */,
 				59986D761F9BA11600D68DC1 /* indigo_ccd_qsi.cpp in Sources */,
 				59C8E7C11DBBB05500AA3F0A /* indigo_ccd_simulator.c in Sources */,
 				59EF8BC924683B2A009D75C5 /* indigo_dome_baader.c in Sources */,
 				9DA71D072A029BE500CFA533 /* indigo_ica_ptp_canon.m in Sources */,
 				591F329324211F3C00D1D64B /* indigo_dome_dragonfly.c in Sources */,
-				59FA0B2022FCACC700A15D19 /* indigo_ptp_canon.c in Sources */,
 				9D62F70128FEAF62006599FF /* indigo_agent_config.c in Sources */,
 				5911B6CB22630FE900D6B9EC /* indigo_raw_utils.c in Sources */,
 				597C7225293CFC3A0016D45A /* indigo_ccd_asi.c in Sources */,
 				59FE34652187B2F8004FB5D4 /* indigo_aux_dsusb.c in Sources */,
 				59A242F622A5B45F001C38F8 /* indigo_focuser_steeldrive2.c in Sources */,
-				59C3BB12255077E9000720B4 /* indigo_ptp_fuji.c in Sources */,
 				9D85FAE521E38E3900ECDF82 /* indigo_agent_alignment.c in Sources */,
 				9DAD524E2126E88B002FCC79 /* indigo_wheel_trutek.c in Sources */,
 				599A63B01DEA2F4700ABC827 /* indigo_driver_json.c in Sources */,
@@ -14597,15 +14612,13 @@
 				59111D03285F504300E57194 /* indigocat_uranus.c in Sources */,
 				59C76F0E2378724D0091B966 /* nex_open.c in Sources */,
 				59D707701DC52C3E00DEF566 /* indigo_mount_simulator.c in Sources */,
-				59D6719222FDBB8E00D08A2A /* indigo_ptp_sony.c in Sources */,
+				5937CBE82A02BEE100135CCF /* indigo_ptp_nikon.m in Sources */,
 				591CD0E829805CB9003243AE /* indigo_ccd_rising.c in Sources */,
 				597DFE242804A880009E37CB /* indigo_rotator_optec.c in Sources */,
 				9D73E61E21FF37F9003CEC15 /* libuvc_stream.c in Sources */,
 				9DAD523121246EB5002FCC79 /* indigo_mount_ioptron.c in Sources */,
 				59DD69C91FC1CF8D00AEF0DF /* indigo_gps_nmea.c in Sources */,
 				590B59D41F7858FE00086FD2 /* indigo_mount_temma.c in Sources */,
-				9DA71CF32A025A0A00CFA533 /* indigo_ptp.c in Sources */,
-				59D6718E22FDBB7500D08A2A /* indigo_ptp_nikon.c in Sources */,
 				595F292E211E211200380EF4 /* DDHidElement.m in Sources */,
 				9D4F4742215A4447006110FD /* indigo_focuser_moonlite.c in Sources */,
 				59413566232404D700ED5FF4 /* indigo_focuser_efa.c in Sources */,
@@ -14719,6 +14732,7 @@
 				595567D824BA00DA00DF303D /* indigo_mount_pmc8_main.c in Sources */,
 				59D62CDB1E731B62004DDD9C /* indigo_focuser_usbv3.c in Sources */,
 				59FE347C2187B7DD004FB5D4 /* indigo_guider_gpusb.c in Sources */,
+				5937CBEE2A02BEF700135CCF /* indigo_ptp_fuji.m in Sources */,
 				599C9A511DA022E3008BBCC1 /* indigo_driver_xml.c in Sources */,
 				5910D9B7258008190015D915 /* indigo_agent_scripting.c in Sources */,
 				59111D02285F504300E57194 /* indigocat_mars.c in Sources */,
@@ -14728,6 +14742,7 @@
 				59B51350297066040075C8A1 /* indigo_wheel_indigo.c in Sources */,
 				59BBED27278493E400BA9CD6 /* indigo_agent_astap.c in Sources */,
 				59D138A5283E6BAA00FCC514 /* indigo_dslr_raw.c in Sources */,
+				5937CBEB2A02BEEB00135CCF /* indigo_ptp_sony.m in Sources */,
 				9DA71D012A029BE500CFA533 /* indigo_ccd_ica.m in Sources */,
 				59A321B821D691D600EC0F4A /* indigo_mount_synscan_guider.c in Sources */,
 				595AA1CD1FC5ED8A00350E7B /* indigo_agent_snoop.c in Sources */,
@@ -14795,6 +14810,7 @@
 				5979C862254710B0005395BE /* indigo_tiff.c in Sources */,
 				9D48B7B6215E5B6100CF757E /* indigo_ccd_touptek.c in Sources */,
 				9DE0E7C222C6465500289234 /* indigo_focuser_dsd.c in Sources */,
+				5937CBE52A02BED800135CCF /* indigo_ptp_canon.m in Sources */,
 				59B636B020A74CD400EF2D52 /* indigo_usb_utils.c in Sources */,
 				595B88EC242CFEA2008CA4E2 /* indigo_token.c in Sources */,
 				59F1AD1223FB15B300008F02 /* indigo_focuser_lunatico.c in Sources */,

--- a/indigo.xcodeproj/project.pbxproj
+++ b/indigo.xcodeproj/project.pbxproj
@@ -1221,6 +1221,7 @@
 		5937CBEA2A02BEEB00135CCF /* indigo_ptp_sony.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = indigo_ptp_sony.m; sourceTree = "<group>"; };
 		5937CBED2A02BEF700135CCF /* indigo_ptp_fuji.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = indigo_ptp_fuji.m; sourceTree = "<group>"; };
 		5937CBF32A02C25900135CCF /* indigo_ptp_ica.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = indigo_ptp_ica.h; sourceTree = "<group>"; };
+		5937CBF72A02E70200135CCF /* Makefile */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
 		59399D892177D316002886CA /* indigo_focuser_optec.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = indigo_focuser_optec.c; sourceTree = "<group>"; };
 		59399D8A2177D316002886CA /* indigo_focuser_optec_main.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = indigo_focuser_optec_main.c; sourceTree = "<group>"; };
 		59399D8B2177D316002886CA /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -12843,6 +12844,7 @@
 			isa = PBXGroup;
 			children = (
 				9D586C3D22FB0C34002D382E /* README.md */,
+				5937CBF72A02E70200135CCF /* Makefile */,
 				9D586C3E22FB0D43002D382E /* indigo_ccd_ptp.h */,
 				9D586C3F22FB0D43002D382E /* indigo_ccd_ptp.c */,
 				59FA0B1C22FB400900A15D19 /* indigo_ptp.h */,

--- a/indigo_drivers/ccd_ptp/Makefile
+++ b/indigo_drivers/ccd_ptp/Makefile
@@ -1,0 +1,123 @@
+#---------------------------------------------------------------------
+#
+# Copyright (c) 2023 CloudMakers, s. r. o.
+# All rights reserved.
+#
+# You can use this software under the terms of 'INDIGO Astronomy
+# open-source license' (see LICENSE.md).
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHORS 'AS IS' AND ANY EXPRESS
+# OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+# GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#---------------------------------------------------------------------
+
+include ../../Makefile.inc
+
+DRIVER = indigo_ccd_ptp
+
+DRIVER_A = $(BUILD_DRIVERS)/$(DRIVER).a
+DRIVER_SO = $(BUILD_DRIVERS)/$(DRIVER).$(SOEXT)
+DRIVER_EXECUTABLE = $(BUILD_DRIVERS)/$(DRIVER)
+
+ifeq ($(OS_DETECTED),Darwin)
+	FORCE_ALL_ON=-Wl,-force_load
+	FORCE_ALL_OFF=
+endif
+ifeq ($(OS_DETECTED),Linux)
+	FORCE_ALL_ON=-Wl,--whole-archive
+	FORCE_ALL_OFF=-Wl,--no-whole-archive
+endif
+
+
+.PHONY: all status install uninstall clean clean-all
+
+all: status $(DRIVER_A) $(DRIVER_SO) $(DRIVER_EXECUTABLE)
+
+status:
+	@printf "\n$(DRIVER) ---------------------------------------\n\n"
+	@printf "Archive:    $(notdir $(DRIVER_A))\n"
+	@printf "SO library: $(notdir $(DRIVER_SO))\n"
+	@printf "Executable: $(notdir $(DRIVER_EXECUTABLE))\n"
+	@printf "\n"
+
+ifeq ($(OS_DETECTED),Darwin)
+
+indigo_ccd_ptp.o: indigo_ccd_ptp.m
+	$(CC) $(MFLAGS) -c -o $@ $<
+
+indigo_ptp.o: indigo_ptp.m
+	$(CC) $(MFLAGS) -c -o $@ $<
+
+indigo_ptp_canon.o: indigo_ptp_canon.m
+	$(CC) $(MFLAGS) -c -o $@ $<
+
+indigo_ptp_nikon.o: indigo_ptp_nikon.m
+	$(CC) $(MFLAGS) -c -o $@ $<
+
+indigo_ptp_sony.o: indigo_ptp_sony.m
+	$(CC) $(MFLAGS) -c -o $@ $<
+
+indigo_ptp_fuji.o: indigo_ptp_fuji.m
+	$(CC) $(MFLAGS) -c -o $@ $<
+
+$(DRIVER_EXECUTABLE): indigo_ccd_ptp_main.o $(DRIVER_A)
+	$(CC) -o $@ $^ $(LDFLAGS) -lindigo -framework IOKit -framework Cocoa
+
+$(DRIVER_SO): $(DRIVER_A)
+	$(CC) -shared -o $@ $(FORCE_ALL_ON) $(DRIVER_A) $(FORCE_ALL_OFF) $(LDFLAGS) -lindigo -framework IOKit -framework Cocoa
+
+endif
+
+ifeq ($(OS_DETECTED),Linux)
+
+indigo_ccd_ptp.o: indigo_ccd_ptp.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+indigo_ptp.o: indigo_ptp.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+indigo_ptp_canon.o: indigo_ptp_canon.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+indigo_ptp_nikon.o: indigo_ptp_nikon.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+indigo_ptp_sony.o: indigo_ptp_sony.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+indigo_ptp_fuji.o: indigo_ptp_fuji.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+$(DRIVER_EXECUTABLE): indigo_ccd_ptp_main.o $(DRIVER_A)
+	$(CC) -o $@ $^ $(LDFLAGS) -lindigo -lusb-1.0
+
+$(DRIVER_SO): $(DRIVER_A)
+	$(CC) -shared -o $@ $(FORCE_ALL_ON) $(DRIVER_A) $(FORCE_ALL_OFF) $(LDFLAGS) -lindigo -lusb-1.0
+
+endif
+
+$(DRIVER_A): indigo_ccd_ptp.o indigo_ptp.o indigo_ptp_canon.o indigo_ptp_nikon.o indigo_ptp_sony.o indigo_ptp_fuji.o
+	$(AR) $(ARFLAGS) $@ $^
+
+install: status
+	install -m 0644 $(DRIVER_SO) $(INSTALL_LIB)
+	install -m 0755 $(DRIVER_EXECUTABLE) $(INSTALL_BIN)
+
+uninstall: status
+	rm -f $(INSTALL_LIB)/$(DRIVER).$(SOEXT) $(INSTALL_BIN)/$(DRIVER)
+
+clean: status
+	rm -f *.o $(DRIVER_A) $(DRIVER_SO) $(DRIVER_EXECUTABLE)
+
+clean-all: clean
+
+

--- a/indigo_drivers/ccd_ptp/Makefile
+++ b/indigo_drivers/ccd_ptp/Makefile
@@ -51,23 +51,23 @@ status:
 
 ifeq ($(OS_DETECTED),Darwin)
 
-indigo_ccd_ptp.o: indigo_ccd_ptp.m
-	$(CC) $(MFLAGS) -c -o $@ $<
+indigo_ccd_ptp.o: indigo_ccd_ptp.m indigo_ccd_ptp.c
+	$(CC) $(MFLAGS) -c -o $@ indigo_ccd_ptp.m
 
-indigo_ptp.o: indigo_ptp.m
-	$(CC) $(MFLAGS) -c -o $@ $<
+indigo_ptp.o: indigo_ptp.m indigo_ptp.c
+	$(CC) $(MFLAGS) -c -o $@ indigo_ptp.m
 
-indigo_ptp_canon.o: indigo_ptp_canon.m
-	$(CC) $(MFLAGS) -c -o $@ $<
+indigo_ptp_canon.o: indigo_ptp_canon.m  indigo_ptp_canon.c
+	$(CC) $(MFLAGS) -c -o $@ indigo_ptp_canon.m
 
-indigo_ptp_nikon.o: indigo_ptp_nikon.m
-	$(CC) $(MFLAGS) -c -o $@ $<
+indigo_ptp_nikon.o: indigo_ptp_nikon.m  indigo_ptp_nikon.c
+	$(CC) $(MFLAGS) -c -o $@ indigo_ptp_nikon.m
 
-indigo_ptp_sony.o: indigo_ptp_sony.m
-	$(CC) $(MFLAGS) -c -o $@ $<
+indigo_ptp_sony.o: indigo_ptp_sony.m  indigo_ptp_sony.c
+	$(CC) $(MFLAGS) -c -o $@ indigo_ptp_sony.m
 
-indigo_ptp_fuji.o: indigo_ptp_fuji.m
-	$(CC) $(MFLAGS) -c -o $@ $<
+indigo_ptp_fuji.o: indigo_ptp_fuji.m  indigo_ptp_fuji.c
+	$(CC) $(MFLAGS) -c -o $@ indigo_ptp_fuji.m
 
 $(DRIVER_EXECUTABLE): indigo_ccd_ptp_main.o $(DRIVER_A)
 	$(CC) -o $@ $^ $(LDFLAGS) -lindigo -framework IOKit -framework Cocoa

--- a/indigo_drivers/ccd_ptp/indigo_ccd_ptp.c
+++ b/indigo_drivers/ccd_ptp/indigo_ccd_ptp.c
@@ -692,12 +692,11 @@ static indigo_device *attach_device(int vendor, int product, const char *usb_pat
 -(void)deviceBrowser:(ICDeviceBrowser*)browser didRemoveDevice:(ICDevice*)dev moreGoing:(BOOL)moreGoing {
 	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
 		pthread_mutex_lock(&device_mutex);
-		ptp_private_data *private_data = NULL;
 		for (int j = 0; j < MAX_DEVICES; j++) {
 			if (devices[j] != NULL) {
 				indigo_device *device = devices[j];
 				if (PRIVATE_DATA->dev == dev) {
-					private_data = PRIVATE_DATA;
+					ptp_private_data *private_data = PRIVATE_DATA;
 					if (private_data->focuser) {
 						indigo_detach_device(private_data->focuser);
 						free(private_data->focuser);
@@ -706,13 +705,11 @@ static indigo_device *attach_device(int vendor, int product, const char *usb_pat
 					indigo_detach_device(device);
 					free(device);
 					devices[j] = NULL;
+					if (private_data->vendor_private_data)
+						free(private_data->vendor_private_data);
+					free(private_data);
 				}
 			}
-		}
-		if (private_data != NULL) {
-			if (private_data->vendor_private_data)
-				free(private_data->vendor_private_data);
-			free(private_data);
 		}
 		pthread_mutex_unlock(&device_mutex);
 	});

--- a/indigo_drivers/ccd_ptp/indigo_ccd_ptp.c
+++ b/indigo_drivers/ccd_ptp/indigo_ccd_ptp.c
@@ -203,8 +203,8 @@ static void handle_connection(indigo_device *device) {
 		}
 		pthread_mutex_unlock(&PRIVATE_DATA->message_mutex);
 	} else {
+    indigo_cancel_timer_sync(device, &PRIVATE_DATA->event_checker);
 		indigo_detach_device(PRIVATE_DATA->focuser);
-		indigo_cancel_timer_sync(device, &PRIVATE_DATA->event_checker);
 #ifndef USE_ICA_TRANSPORT
 		ptp_transaction_0_0(device, ptp_operation_CloseSession);
 #endif
@@ -671,51 +671,51 @@ static indigo_device *attach_device(int vendor, int product, const char *usb_pat
 
 -(void)start {
 	[icBrowser start];
-	INDIGO_DRIVER_DEBUG(DRIVER_NAME, "browser started");
 }
 
 -(void)stop {
 	[icBrowser stop];
-	INDIGO_DRIVER_DEBUG(DRIVER_NAME, "browser stopped");
 }
 
 -(void)deviceBrowser:(ICDeviceBrowser*)browser didAddDevice:(ICDevice*)dev moreComing:(BOOL)moreComing {
-	pthread_mutex_lock(&device_mutex);
-	INDIGO_DRIVER_DEBUG(DRIVER_NAME, "device added %s", [dev.description cStringUsingEncoding:NSUTF8StringEncoding]);
-	char usb_path[INDIGO_NAME_SIZE];
-	snprintf(usb_path, INDIGO_NAME_SIZE, "%08x", dev.usbLocationID);
-	indigo_device *device = attach_device(dev.usbVendorID, dev.usbProductID, usb_path);
-	PRIVATE_DATA->dev = (ICCameraDevice *)dev;
-	[dev.userData setObject:[NSValue valueWithPointer:device] forKey:@"device"];
-	pthread_mutex_unlock(&device_mutex);
+	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+		pthread_mutex_lock(&device_mutex);
+		char usb_path[INDIGO_NAME_SIZE];
+		snprintf(usb_path, INDIGO_NAME_SIZE, "%08x", dev.usbLocationID);
+		indigo_device *device = attach_device(dev.usbVendorID, dev.usbProductID, usb_path);
+		PRIVATE_DATA->dev = (ICCameraDevice *)dev;
+		[dev.userData setObject:[NSValue valueWithPointer:device] forKey:@"device"];
+		pthread_mutex_unlock(&device_mutex);
+	});
 }
 
 -(void)deviceBrowser:(ICDeviceBrowser*)browser didRemoveDevice:(ICDevice*)dev moreGoing:(BOOL)moreGoing {
-	pthread_mutex_lock(&device_mutex);
-	INDIGO_DRIVER_DEBUG(DRIVER_NAME, "device removed %s", [dev.name cStringUsingEncoding:NSUTF8StringEncoding]);
-	ptp_private_data *private_data = NULL;
-	for (int j = 0; j < MAX_DEVICES; j++) {
-		if (devices[j] != NULL) {
-			indigo_device *device = devices[j];
-			if (PRIVATE_DATA->dev == dev) {
-				private_data = PRIVATE_DATA;
-				if (private_data->focuser) {
-					indigo_detach_device(private_data->focuser);
-					free(private_data->focuser);
-					private_data->focuser = NULL;
+	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+		pthread_mutex_lock(&device_mutex);
+		ptp_private_data *private_data = NULL;
+		for (int j = 0; j < MAX_DEVICES; j++) {
+			if (devices[j] != NULL) {
+				indigo_device *device = devices[j];
+				if (PRIVATE_DATA->dev == dev) {
+					private_data = PRIVATE_DATA;
+					if (private_data->focuser) {
+						indigo_detach_device(private_data->focuser);
+						free(private_data->focuser);
+						private_data->focuser = NULL;
+					}
+					indigo_detach_device(device);
+					free(device);
+					devices[j] = NULL;
 				}
-				indigo_detach_device(device);
-				free(device);
-				devices[j] = NULL;
 			}
 		}
-	}
-	if (private_data != NULL) {
-		if (private_data->vendor_private_data)
-			free(private_data->vendor_private_data);
-		free(private_data);
-	}
-	pthread_mutex_unlock(&device_mutex);
+		if (private_data != NULL) {
+			if (private_data->vendor_private_data)
+				free(private_data->vendor_private_data);
+			free(private_data);
+		}
+		pthread_mutex_unlock(&device_mutex);
+	});
 }
 @end
 

--- a/indigo_drivers/ccd_ptp/indigo_ccd_ptp.m
+++ b/indigo_drivers/ccd_ptp/indigo_ccd_ptp.m
@@ -1,0 +1,14 @@
+//
+//  indigo_ccd_ptp.m
+//  indigo
+//
+//  Created by Polakovic Peter on 03/05/2023.
+//  Copyright © 2023 CloudMakers, s. r. o. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+#import <ImageCaptureCore/ImageCaptureCore.h>
+
+#define USE_ICA_TRANSPORT
+
+#import "indigo_ccd_ptp.c"

--- a/indigo_drivers/ccd_ptp/indigo_ptp.c
+++ b/indigo_drivers/ccd_ptp/indigo_ptp.c
@@ -1526,7 +1526,9 @@ bool ptp_refresh_property(indigo_device *device, ptp_property *property) {
 
 static void ptp_check_event(indigo_device *device) {
 	ptp_get_event(device);
-	indigo_reschedule_timer(device, 0, &PRIVATE_DATA->event_checker);
+	if (IS_CONNECTED) {
+		indigo_reschedule_timer(device, 0, &PRIVATE_DATA->event_checker);
+	}
 }
 
 bool ptp_initialise(indigo_device *device) {

--- a/indigo_drivers/ccd_ptp/indigo_ptp.c
+++ b/indigo_drivers/ccd_ptp/indigo_ptp.c
@@ -948,7 +948,6 @@ uint32_t ptp_type_size(ptp_type type) {
 }
 
 - (void)cameraDevice:(nonnull ICCameraDevice *)camera didReceivePTPEvent:(nonnull NSData *)eventData {
-	INDIGO_DRIVER_DEBUG(DRIVER_NAME, "event added %s", [eventData.description cStringUsingEncoding:NSUTF8StringEncoding]);
 	if (_events == nil) {
 		_events = [[NSMutableArray alloc] init];
 	}

--- a/indigo_drivers/ccd_ptp/indigo_ptp.c
+++ b/indigo_drivers/ccd_ptp/indigo_ptp.c
@@ -991,6 +991,9 @@ uint32_t ptp_type_size(ptp_type type) {
 
 bool ptp_open(indigo_device *device) {
 	ICCameraDevice *camera = PRIVATE_DATA->dev;
+	if (camera == NULL) {
+		return false;
+	}
 	ICACameraDelegate *delegate = [[ICACameraDelegate alloc] init];
 	PRIVATE_DATA->delegate = delegate;
 	camera.delegate = delegate;
@@ -1007,6 +1010,9 @@ bool ptp_open(indigo_device *device) {
 bool ptp_transaction(indigo_device *device, uint16_t code, int count, uint32_t out_1, uint32_t out_2, uint32_t out_3, uint32_t out_4, uint32_t out_5, void *data_out, uint32_t data_out_size, uint32_t *in_1, uint32_t *in_2, uint32_t *in_3, uint32_t *in_4, uint32_t *in_5, void **data_in, uint32_t *data_in_size) {
 	ICCameraDevice *camera = PRIVATE_DATA->dev;
 	ICACameraDelegate *delegate = PRIVATE_DATA->delegate;
+	if (camera == NULL || delegate == NULL) {
+		return false;
+	}
 	ptp_container container;
 	memset(&container, 0, sizeof(container));
 	container.length = PTP_CONTAINER_COMMAND_SIZE(count);
@@ -1058,6 +1064,9 @@ bool ptp_transaction(indigo_device *device, uint16_t code, int count, uint32_t o
 
 bool ptp_get_event(indigo_device *device) {
 	ICACameraDelegate *delegate = PRIVATE_DATA->delegate;
+	if (delegate == NULL) {
+		return false;
+	}
 	ptp_container event;
 	NSData *eventData;
 	while ((eventData = delegate.events.lastObject)) {
@@ -1072,6 +1081,9 @@ bool ptp_get_event(indigo_device *device) {
 void ptp_close(indigo_device *device) {
 	ICCameraDevice *camera = PRIVATE_DATA->dev;
 	ICACameraDelegate *delegate = PRIVATE_DATA->delegate;
+	if (camera == NULL || delegate == NULL) {
+		return;
+	}
 	delegate.closeSemafor = dispatch_semaphore_create(0);
 	[camera requestCloseSession];
 	dispatch_semaphore_wait(delegate.closeSemafor, dispatch_time(DISPATCH_TIME_NOW, 10000000000ull));

--- a/indigo_drivers/ccd_ptp/indigo_ptp.c
+++ b/indigo_drivers/ccd_ptp/indigo_ptp.c
@@ -1691,7 +1691,7 @@ double timestamp(void) {
 }
 
 void ptp_blob_exposure_timer(indigo_device *device) {
-	double finish = timestamp() + (int)CCD_EXPOSURE_ITEM->number.value;
+	double finish = timestamp() + CCD_EXPOSURE_ITEM->number.target;
 	double remains = finish;
 	while (!PRIVATE_DATA->abort_capture && remains > 0) {
 		indigo_usleep(10000);

--- a/indigo_drivers/ccd_ptp/indigo_ptp.c
+++ b/indigo_drivers/ccd_ptp/indigo_ptp.c
@@ -179,7 +179,7 @@ char *ptp_event_code_label(uint16_t code) {
 
 char *ptp_property_code_name(uint16_t code) {
 	static char label[INDIGO_NAME_SIZE];
-	sprintf(label, "%04x", code);
+	snprintf(label, INDIGO_NAME_SIZE,  "%04x", code);
 	return label;
 }
 
@@ -242,7 +242,7 @@ char *ptp_property_code_label(uint16_t code) {
 		case ptp_property_MTPPlaybackPosition: return "MTP playback position";
 	}
 	static char label[INDIGO_NAME_SIZE];
-	sprintf(label, "%04x", code);
+	snprintf(label, INDIGO_NAME_SIZE,  "%04x", code);
 	return label;
 }
 
@@ -262,7 +262,7 @@ char *ptp_property_value_code_label(indigo_device *device, uint16_t property, ui
 			break;
 		}
 		case ptp_property_FNumber: {
-			sprintf(label, "f/%g", code / 100.0);
+			snprintf(label, PTP_MAX_CHARS,  "f/%g", code / 100.0);
 			return label;
 		}
 		case ptp_property_ExposureTime: {
@@ -289,7 +289,7 @@ char *ptp_property_value_code_label(indigo_device *device, uint16_t property, ui
 			if (code == 80)
 				return "1/125s";
 			if (code < 100) {
-				sprintf(label, "1/%gs", round(1000.0 / code) * 10);
+				snprintf(label, PTP_MAX_CHARS,  "1/%gs", round(1000.0 / code) * 10);
 				return label;
 			}
 			if (code < 10000) {
@@ -298,25 +298,25 @@ char *ptp_property_value_code_label(indigo_device *device, uint16_t property, ui
 				double fraction_part = modf(fraction, &integral_part);
 				if (fraction_part >= 0.1 && integral_part < 10) {
 					// for 1/2.5s, 1/1.6s, 1/1.3s
-					sprintf(label, "1/%.1fs", fraction);
+					snprintf(label, PTP_MAX_CHARS,  "1/%.1fs", fraction);
 				} else {
-					sprintf(label, "1/%gs", round(fraction));
+					snprintf(label, PTP_MAX_CHARS,  "1/%gs", round(fraction));
 				}
 				return label;
 			}
-			sprintf(label, "%gs", code / 10000.0);
+			snprintf(label, PTP_MAX_CHARS,  "%gs", code / 10000.0);
 			return label;
 		}
 		case ptp_property_ExposureIndex: {
-			sprintf(label, "%lld", code);
+			snprintf(label, PTP_MAX_CHARS,  "%lld", code);
 			return label;
 		}
 		case ptp_property_ExposureBiasCompensation: {
-			sprintf(label, "%.1f", round((int)code / 100.0) / 10.0);
+			snprintf(label, PTP_MAX_CHARS,  "%.1f", round((int)code / 100.0) / 10.0);
 			return label;
 		}
 	}
-	sprintf(label, "%llx", code);
+	snprintf(label, PTP_MAX_CHARS,  "%llx", code);
 	return label;
 }
 
@@ -351,38 +351,38 @@ void ptp_dump_container(int line, const char *function, indigo_device *device, p
 	int offset = 0;
 	switch (container->type) {
 		case ptp_container_command:
-			offset = sprintf(buffer, "request %s (%04x) %08x [", PRIVATE_DATA->operation_code_label(container->code), container->code, container->transaction_id);
+			offset = snprintf(buffer, PTP_MAX_CHARS,  "request %s (%04x) %08x [", PRIVATE_DATA->operation_code_label(container->code), container->code, container->transaction_id);
 			break;
 		case ptp_container_data:
-			offset = sprintf(buffer, "data %04x %08x +%u bytes", container->code, container->transaction_id, container->length - PTP_CONTAINER_HDR_SIZE);
+			offset = snprintf(buffer, PTP_MAX_CHARS,  "data %04x %08x +%u bytes", container->code, container->transaction_id, container->length - PTP_CONTAINER_HDR_SIZE);
 			break;
 		case ptp_container_response:
-			offset = sprintf(buffer, "response %s (%04x) %08x [", PRIVATE_DATA->response_code_label(container->code), container->code, container->transaction_id);
+			offset = snprintf(buffer, PTP_MAX_CHARS,  "response %s (%04x) %08x [", PRIVATE_DATA->response_code_label(container->code), container->code, container->transaction_id);
 			break;
 		case ptp_container_event:
-			offset = sprintf(buffer, "event %s (%04x) [", PRIVATE_DATA->event_code_label(container->code), container->code);
+			offset = snprintf(buffer, PTP_MAX_CHARS,  "event %s (%04x) [", PRIVATE_DATA->event_code_label(container->code), container->code);
 			break;
 		default:
-			offset = sprintf(buffer, "unknown %04x %08x", container->code, container->transaction_id);
+			offset = snprintf(buffer, PTP_MAX_CHARS,  "unknown %04x %08x", container->code, container->transaction_id);
 			break;
 	}
 	if (container->type == ptp_container_command || container->type == ptp_container_response || container->type == ptp_container_event) {
 		if (container->length > 12) {
-			offset += sprintf(buffer + offset, "%08x", container->payload.params[0]);
+			offset += snprintf(buffer + offset, PTP_MAX_CHARS - offset, "%08x", container->payload.params[0]);
 		}
 		if (container->length > 16) {
-			offset += sprintf(buffer + offset, ", %08x", container->payload.params[1]);
+			offset += snprintf(buffer + offset, PTP_MAX_CHARS - offset, ", %08x", container->payload.params[1]);
 		}
 		if (container->length > 20) {
-			offset += sprintf(buffer + offset, ", %08x", container->payload.params[2]);
+			offset += snprintf(buffer + offset, PTP_MAX_CHARS - offset, ", %08x", container->payload.params[2]);
 		}
 		if (container->length > 24) {
-			offset += sprintf(buffer + offset, ", %08x", container->payload.params[3]);
+			offset += snprintf(buffer + offset, PTP_MAX_CHARS - offset, ", %08x", container->payload.params[3]);
 		}
 		if (container->length > 28) {
-			offset += sprintf(buffer + offset, ", %08x", container->payload.params[4]);
+			offset += snprintf(buffer + offset, PTP_MAX_CHARS - offset, ", %08x", container->payload.params[4]);
 		}
-		sprintf(buffer + offset, "]");
+		snprintf(buffer + offset, PTP_MAX_CHARS - offset, "]");
 	}
 	indigo_debug("%s[%s:%d]: %s", DRIVER_NAME, function, line,  buffer);
 }
@@ -470,7 +470,7 @@ uint8_t *ptp_decode_uint128(uint8_t *source, char *target) {
 	source = ptp_decode_uint32(source, &u32_2);
 	source = ptp_decode_uint32(source, &u32_3);
 	source = ptp_decode_uint32(source, &u32_4);
-	sprintf(target, "%04x%04x%04x%04x", u32_4, u32_3, u32_2, u32_1);
+	snprintf(target, 17, "%04x%04x%04x%04x", u32_4, u32_3, u32_2, u32_1);
 	return source;
 }
 
@@ -885,10 +885,184 @@ bool ptp_operation_supported(indigo_device *device, uint16_t code) {
 	return false;
 }
 
+uint32_t ptp_type_size(ptp_type type) {
+	switch (type) {
+	case ptp_int8_type:
+	case ptp_uint8_type:
+		return 1;
+	case ptp_int16_type:
+	case ptp_uint16_type:
+		return 2;
+	case ptp_int32_type:
+	case ptp_uint32_type:
+		return 4;
+	case ptp_int64_type:
+	case ptp_uint64_type:
+		return 8;
+	case ptp_int128_type:
+	case ptp_uint128_type:
+		return 16;
+	// array of integers
+	case ptp_aint8_type:
+	case ptp_auint8_type:
+	case ptp_aint16_type:
+	case ptp_auint16_type:
+	case ptp_aint32_type:
+	case ptp_auint32_type:
+	case ptp_aint64_type:
+	case ptp_auint64_type:
+	case ptp_aint128_type:
+	case ptp_auint128_type:
+	default:
+		return 0;
+	}
+}
+
+#ifdef USE_ICA_TRANSPORT
+
+@implementation ICACameraDelegate {
+}
+
+- (void)device:(nonnull ICDevice *)device didOpenSessionWithError:(NSError * _Nullable)error {
+	if (_openSemafor) {
+		dispatch_semaphore_signal(_openSemafor);
+	}
+}
+
+- (void)device:(nonnull ICDevice *)device didCloseSessionWithError:(NSError * _Nullable)error {
+	if (_closeSemafor) {
+		dispatch_semaphore_signal(_closeSemafor);
+	}
+}
+
+- (void)didRemoveDevice:(nonnull ICDevice *)device {
+}
+
+- (void)cameraDevice:(nonnull ICCameraDevice *)camera didAddItems:(nonnull NSArray<ICCameraItem *> *)items {
+}
+
+- (void)cameraDevice:(nonnull ICCameraDevice *)camera didReceivePTPEvent:(nonnull NSData *)eventData {
+	[_events insertObject:eventData atIndex:0];
+}
+
+- (void)cameraDevice:(nonnull ICCameraDevice *)camera didRemoveItems:(nonnull NSArray<ICCameraItem *> *)items {
+}
+
+- (void)cameraDevice:(nonnull ICCameraDevice *)camera didRenameItems:(nonnull NSArray<ICCameraItem *> *)items {
+}
+
+- (void)cameraDeviceDidChangeCapability:(nonnull ICCameraDevice *)camera {
+}
+
+- (void)cameraDeviceDidEnableAccessRestriction:(nonnull ICDevice *)device {
+}
+
+- (void)cameraDeviceDidRemoveAccessRestriction:(nonnull ICDevice *)device {
+}
+
+- (void)deviceDidBecomeReadyWithCompleteContentCatalog:(nonnull ICCameraDevice *)device {
+}
+
+-(void)didSendPTPCommand:(NSData*)command inData:(NSData*)inData response:(NSData*)response error:(NSError*)error contextInfo:(void*)contextInfo {
+	NSLog(@"didSendPTPCommand %@", error);
+	if (_ptpSemafor) {
+		_ptpResponse = response;
+		_ptpInput = inData;
+		dispatch_semaphore_signal(_ptpSemafor);
+	}
+}
+
+@end
+
+bool ptp_open(indigo_device *device) {
+	ICCameraDevice *camera = PRIVATE_DATA->dev;
+	ICACameraDelegate *delegate = [[ICACameraDelegate alloc] init];
+	PRIVATE_DATA->delegate = delegate;
+	camera.delegate = delegate;
+	delegate.openSemafor = dispatch_semaphore_create(0);
+	delegate.ptpSemafor = dispatch_semaphore_create(0);
+	[camera requestOpenSession];
+	dispatch_semaphore_wait(delegate.openSemafor, DISPATCH_TIME_FOREVER);
+	delegate.openSemafor = nil;
+	return true;
+}
+
+bool ptp_transaction(indigo_device *device, uint16_t code, int count, uint32_t out_1, uint32_t out_2, uint32_t out_3, uint32_t out_4, uint32_t out_5, void *data_out, uint32_t data_out_size, uint32_t *in_1, uint32_t *in_2, uint32_t *in_3, uint32_t *in_4, uint32_t *in_5, void **data_in, uint32_t *data_in_size) {
+	ICCameraDevice *camera = PRIVATE_DATA->dev;
+	ICACameraDelegate *delegate = PRIVATE_DATA->delegate;
+	ptp_container container;
+	memset(&container, 0, sizeof(container));
+	container.length = PTP_CONTAINER_COMMAND_SIZE(count);
+	container.type = ptp_container_command;
+	container.code = code;
+	container.transaction_id = PRIVATE_DATA->transaction_id++;
+	container.payload.params[0] = out_1;
+	container.payload.params[1] = out_2;
+	container.payload.params[2] = out_3;
+	container.payload.params[3] = out_4;
+	container.payload.params[4] = out_5;
+	PTP_DUMP_CONTAINER(&container);
+	NSData *requestData = [NSData dataWithBytesNoCopy:&container length:container.length freeWhenDone:YES];
+	NSData *outData = data_out ? [NSData dataWithBytesNoCopy:data_out length:data_out_size freeWhenDone:YES] : nil;
+	[camera requestSendPTPCommand:requestData outData:outData sendCommandDelegate:delegate didSendCommandSelector:@selector(didSendPTPCommand:inData:response:error:contextInfo:) contextInfo:nil];
+	dispatch_semaphore_wait(delegate.ptpSemafor, DISPATCH_TIME_FOREVER);
+	[delegate.ptpResponse getBytes:&container length:sizeof(container)];
+	PTP_DUMP_CONTAINER(&container);
+	if (in_1)
+		*in_1 = container.payload.params[0];
+	if (in_2)
+		*in_2 = container.payload.params[1];
+	if (in_3)
+		*in_3 = container.payload.params[2];
+	if (in_4)
+		*in_4 = container.payload.params[3];
+	if (in_5)
+		*in_5 = container.payload.params[4];
+	delegate.ptpResponse = nil;
+	if (delegate.ptpInput && data_in) {
+		*data_in = malloc(delegate.ptpInput.length);
+		if (data_in_size) {
+			*data_in_size = (int)delegate.ptpInput.length;
+		}
+		[delegate.ptpInput getBytes:*data_in length:delegate.ptpInput.length];
+		delegate.ptpInput = nil;
+	}
+	PRIVATE_DATA->last_error = container.code;
+	return container.code == ptp_response_OK;
+}
+
+bool ptp_get_event(indigo_device *device) {
+	ICACameraDelegate *delegate = PRIVATE_DATA->delegate;
+	ptp_container event;
+	NSData *eventData;
+	while ((eventData = delegate.events.lastObject)) {
+		[delegate.events removeLastObject];
+		[eventData getBytes:&event length:sizeof(event)];
+		PTP_DUMP_CONTAINER(&event);
+		PRIVATE_DATA->handle_event(device, event.code, event.payload.params);
+	}
+	return true;
+}
+
+void ptp_close(indigo_device *device) {
+	ICCameraDevice *camera = PRIVATE_DATA->dev;
+	ICACameraDelegate *delegate = PRIVATE_DATA->delegate;
+	delegate.closeSemafor = dispatch_semaphore_create(0);
+	[camera requestCloseSession];
+	dispatch_semaphore_wait(delegate.closeSemafor, DISPATCH_TIME_FOREVER);
+	delegate.closeSemafor = nil;
+	delegate.ptpSemafor = nil;
+	camera.delegate = nil;
+	PRIVATE_DATA->delegate = nil;
+}
+
+#else
+
 bool ptp_open(indigo_device *device) {
 	pthread_mutex_lock(&PRIVATE_DATA->usb_mutex);
 	int rc = 0;
 	struct libusb_device_descriptor	device_descriptor;
+	
 	libusb_device *dev = PRIVATE_DATA->dev;
 	rc = libusb_get_device_descriptor(dev, &device_descriptor);
 	INDIGO_DRIVER_DEBUG(DRIVER_NAME, "libusb_get_device_descriptor() -> %s", rc < 0 ? libusb_error_name(rc) : "OK");
@@ -973,39 +1147,6 @@ bool ptp_open(indigo_device *device) {
 	}
 	pthread_mutex_unlock(&PRIVATE_DATA->usb_mutex);
 	return rc >= 0;
-}
-
-uint32_t ptp_type_size(ptp_type type) {
-	switch (type) {
-	case ptp_int8_type:
-	case ptp_uint8_type:
-		return 1;
-	case ptp_int16_type:
-	case ptp_uint16_type:
-		return 2;
-	case ptp_int32_type:
-	case ptp_uint32_type:
-		return 4;
-	case ptp_int64_type:
-	case ptp_uint64_type:
-		return 8;
-	case ptp_int128_type:
-	case ptp_uint128_type:
-		return 16;
-	// array of integers
-	case ptp_aint8_type:
-	case ptp_auint8_type:
-	case ptp_aint16_type:
-	case ptp_auint16_type:
-	case ptp_aint32_type:
-	case ptp_auint32_type:
-	case ptp_aint64_type:
-	case ptp_auint64_type:
-	case ptp_aint128_type:
-	case ptp_auint128_type:
-	default:
-		return 0;
-	}
 }
 
 bool ptp_transaction(indigo_device *device, uint16_t code, int count, uint32_t out_1, uint32_t out_2, uint32_t out_3, uint32_t out_4, uint32_t out_5, void *data_out, uint32_t data_out_size, uint32_t *in_1, uint32_t *in_2, uint32_t *in_3, uint32_t *in_4, uint32_t *in_5, void **data_in, uint32_t *data_in_size) {
@@ -1130,6 +1271,25 @@ bool ptp_transaction(indigo_device *device, uint16_t code, int count, uint32_t o
 	return rc >= 0 && response.code == ptp_response_OK;
 }
 
+bool ptp_get_event(indigo_device *device) {
+	ptp_container event;
+	int length = 0;
+	memset(&event, 0, sizeof(event));
+	pthread_mutex_lock(&PRIVATE_DATA->usb_mutex);
+	int rc = libusb_bulk_transfer(PRIVATE_DATA->handle, PRIVATE_DATA->ep_int, (unsigned char *)&event, sizeof(event), &length, PTP_TIMEOUT);
+	INDIGO_DRIVER_DEBUG(DRIVER_NAME, "libusb_bulk_transfer() -> %s, %d", rc < 0 ? libusb_error_name(rc) : "OK", length);
+	if (rc < 0) {
+		rc = libusb_clear_halt(PRIVATE_DATA->handle, PRIVATE_DATA->ep_int);
+		INDIGO_DRIVER_DEBUG(DRIVER_NAME, "libusb_clear_halt() -> %s", rc < 0 ? libusb_error_name(rc) : "OK");
+		pthread_mutex_unlock(&PRIVATE_DATA->usb_mutex);
+		return false;
+	}
+	PTP_DUMP_CONTAINER(&event);
+	pthread_mutex_unlock(&PRIVATE_DATA->usb_mutex);
+	PRIVATE_DATA->handle_event(device, event.code, event.payload.params);
+	return true;
+}
+
 void ptp_close(indigo_device *device) {
 	pthread_mutex_lock(&PRIVATE_DATA->usb_mutex);
 	libusb_close(PRIVATE_DATA->handle);
@@ -1137,6 +1297,8 @@ void ptp_close(indigo_device *device) {
 	PRIVATE_DATA->handle = NULL;
 	pthread_mutex_unlock(&PRIVATE_DATA->usb_mutex);
 }
+
+#endif
 
 bool ptp_update_property(indigo_device *device, ptp_property *property) {
 	bool define = false, delete = false, update = false;
@@ -1188,7 +1350,7 @@ bool ptp_update_property(indigo_device *device, ptp_property *property) {
 						indigo_init_switch_item(property->property->items + i, str, str, !strcmp(property->value.sw_str.value, str));
 					} else {
 						indigo_item *item = property->property->items + i;
-						sprintf(str, "%llx", property->value.sw.values[i]);
+						snprintf(str, INDIGO_VALUE_SIZE, "%llx", property->value.sw.values[i]);
 						indigo_init_switch_item(item, str, PRIVATE_DATA->property_value_code_label(device, property->code, property->value.sw.values[i]), property->value.sw.value == property->value.sw.values[i]);
 						if (!strcmp(item->label, "+") || !strcmp(item->label, "-")) {
 							strcpy(item->name, item->label);
@@ -1232,7 +1394,7 @@ bool ptp_update_property(indigo_device *device, ptp_property *property) {
 						strcpy(str, property->value.sw_str.values[i]);
 						indigo_copy_value(property->property->items[i].label, str);
 					} else {
-						sprintf(str, "%llx", property->value.sw.values[i]);
+						snprintf(str, INDIGO_NAME_SIZE, "%llx", property->value.sw.values[i]);
 						indigo_copy_value(property->property->items[i].label, PRIVATE_DATA->property_value_code_label(device, property->code, property->value.sw.values[i]));
 					}
 					if (strncmp(property->property->items[i].name, str, INDIGO_NAME_SIZE)) {
@@ -1324,25 +1486,6 @@ bool ptp_refresh_property(indigo_device *device, ptp_property *property) {
 			free(buffer);
 	}
 	return result;
-}
-
-bool ptp_get_event(indigo_device *device) {
-	ptp_container event;
-	int length = 0;
-	memset(&event, 0, sizeof(event));
-	pthread_mutex_lock(&PRIVATE_DATA->usb_mutex);
-	int rc = libusb_bulk_transfer(PRIVATE_DATA->handle, PRIVATE_DATA->ep_int, (unsigned char *)&event, sizeof(event), &length, PTP_TIMEOUT);
-	INDIGO_DRIVER_DEBUG(DRIVER_NAME, "libusb_bulk_transfer() -> %s, %d", rc < 0 ? libusb_error_name(rc) : "OK", length);
-	if (rc < 0) {
-		rc = libusb_clear_halt(PRIVATE_DATA->handle, PRIVATE_DATA->ep_int);
-		INDIGO_DRIVER_DEBUG(DRIVER_NAME, "libusb_clear_halt() -> %s", rc < 0 ? libusb_error_name(rc) : "OK");
-		pthread_mutex_unlock(&PRIVATE_DATA->usb_mutex);
-		return false;
-	}
-	PTP_DUMP_CONTAINER(&event);
-	pthread_mutex_unlock(&PRIVATE_DATA->usb_mutex);
-	PRIVATE_DATA->handle_event(device, event.code, event.payload.params);
-	return true;
 }
 
 static void ptp_check_event(indigo_device *device) {
@@ -1492,7 +1635,7 @@ bool ptp_set_host_time(indigo_device *device) {
 		time_t secs = time(NULL);
 		struct tm tm = *localtime_r(&secs, &tm);
 		char iso_time[16];
-		sprintf(iso_time, "%02d%02d%02dT%02d%02d%02d", tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec);
+		snprintf(iso_time, 16, "%02d%02d%02dT%02d%02d%02d", tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec);
 		uint8_t buffer[2 * PTP_MAX_CHARS + 2];
 		uint8_t *end = ptp_encode_string(iso_time, buffer);
 		return ptp_transaction_0_1_o(device, ptp_operation_SetDevicePropValue, ptp_property_DateTime, buffer, (uint32_t)(end - buffer));

--- a/indigo_drivers/ccd_ptp/indigo_ptp.c
+++ b/indigo_drivers/ccd_ptp/indigo_ptp.c
@@ -949,6 +949,9 @@ uint32_t ptp_type_size(ptp_type type) {
 
 - (void)cameraDevice:(nonnull ICCameraDevice *)camera didReceivePTPEvent:(nonnull NSData *)eventData {
 	INDIGO_DRIVER_DEBUG(DRIVER_NAME, "event added %s", [eventData.description cStringUsingEncoding:NSUTF8StringEncoding]);
+	if (_events == nil) {
+		_events = [[NSMutableArray alloc] init];
+	}
 	[_events insertObject:eventData atIndex:0];
 }
 

--- a/indigo_drivers/ccd_ptp/indigo_ptp.h
+++ b/indigo_drivers/ccd_ptp/indigo_ptp.h
@@ -26,10 +26,14 @@
 #ifndef indigo_ptp_h
 #define indigo_ptp_h
 
+#ifdef USE_ICA_TRANSPORT
+#import "indigo_ptp_ica.h"
+#endif
+
 #include <indigo/indigo_driver.h>
 
 #define PRIVATE_DATA                ((ptp_private_data *)device->private_data)
-#define DRIVER_VERSION              0x001B
+#define DRIVER_VERSION              0x001C
 #define DRIVER_NAME                 "indigo_ccd_ptp"
 
 #define PTP_TIMEOUT                 10000
@@ -342,7 +346,12 @@ typedef struct {
 typedef struct {
 	void *vendor_private_data;
 	indigo_device *focuser;
+#ifdef USE_ICA_TRANSPORT
+	ICCameraDevice *dev;
+	ICACameraDelegate *delegate;
+#else
 	libusb_device *dev;
+#endif
 	libusb_device_handle *handle;
 	uint8_t ep_in, ep_out, ep_int;
 	indigo_property *dslr_delete_image_property;

--- a/indigo_drivers/ccd_ptp/indigo_ptp.m
+++ b/indigo_drivers/ccd_ptp/indigo_ptp.m
@@ -20,9 +20,9 @@
 // 2.0 by Peter Polakovic <peter.polakovic@cloudmakers.eu>
 
 /** INDIGO PTP DSLR driver - ICA bridge
- \file indigo_ccd_ptp.m
+ \file indigo_ptp.m
  */
 
 #define USE_ICA_TRANSPORT
 
-#import "indigo_ccd_ptp.c"
+#import "indigo_ptp.c"

--- a/indigo_drivers/ccd_ptp/indigo_ptp_canon.c
+++ b/indigo_drivers/ccd_ptp/indigo_ptp_canon.c
@@ -1265,7 +1265,9 @@ static void ptp_canon_get_event(indigo_device *device) {
 
 static void ptp_canon_check_event(indigo_device *device) {
 	ptp_canon_get_event(device);
-	indigo_reschedule_timer(device, 1, &PRIVATE_DATA->event_checker);
+	if (IS_CONNECTED) {
+		indigo_reschedule_timer(device, 1, &PRIVATE_DATA->event_checker);
+	}
 }
 
 bool ptp_canon_initialise(indigo_device *device) {

--- a/indigo_drivers/ccd_ptp/indigo_ptp_canon.m
+++ b/indigo_drivers/ccd_ptp/indigo_ptp_canon.m
@@ -20,9 +20,9 @@
 // 2.0 by Peter Polakovic <peter.polakovic@cloudmakers.eu>
 
 /** INDIGO PTP DSLR driver - ICA bridge
- \file indigo_ccd_ptp.m
+ \file indigo_ptp_canon.m
  */
 
 #define USE_ICA_TRANSPORT
 
-#import "indigo_ccd_ptp.c"
+#import "indigo_ptp_canon.c"

--- a/indigo_drivers/ccd_ptp/indigo_ptp_fuji.c
+++ b/indigo_drivers/ccd_ptp/indigo_ptp_fuji.c
@@ -404,12 +404,13 @@ static void ptp_fuji_get_event(indigo_device *device) {
 	}
 	if (buffer)
 		free(buffer);
-	indigo_reschedule_timer(device, 1, &PRIVATE_DATA->event_checker);
 }
 
 static void ptp_fuji_check_event(indigo_device *device) {
 	ptp_fuji_get_event(device);
-	indigo_reschedule_timer(device, 1, &PRIVATE_DATA->event_checker);
+	if (IS_CONNECTED) {
+		indigo_reschedule_timer(device, 1, &PRIVATE_DATA->event_checker);
+	}
 }
 
 bool ptp_fuji_initialise(indigo_device *device) {

--- a/indigo_drivers/ccd_ptp/indigo_ptp_fuji.m
+++ b/indigo_drivers/ccd_ptp/indigo_ptp_fuji.m
@@ -20,9 +20,9 @@
 // 2.0 by Peter Polakovic <peter.polakovic@cloudmakers.eu>
 
 /** INDIGO PTP DSLR driver - ICA bridge
- \file indigo_ccd_ptp.m
+ \file indigo_ptp_fuji.m
  */
 
 #define USE_ICA_TRANSPORT
 
-#import "indigo_ccd_ptp.c"
+#import "indigo_ptp_fuji.c"

--- a/indigo_drivers/ccd_ptp/indigo_ptp_ica.h
+++ b/indigo_drivers/ccd_ptp/indigo_ptp_ica.h
@@ -20,9 +20,22 @@
 // 2.0 by Peter Polakovic <peter.polakovic@cloudmakers.eu>
 
 /** INDIGO PTP DSLR driver - ICA bridge
- \file indigo_ccd_ptp.m
+ \file indigo_ccd_ptp_ica.h
  */
 
-#define USE_ICA_TRANSPORT
+#import <Cocoa/Cocoa.h>
+#import <ImageCaptureCore/ImageCaptureCore.h>
 
-#import "indigo_ccd_ptp.c"
+#pragma clang diagnostic ignored "-Wnullability-completeness"
+
+@interface ICABrowser : NSObject <ICDeviceBrowserDelegate>
+@end
+
+@interface ICACameraDelegate: NSObject<ICCameraDeviceDelegate>
+@property dispatch_semaphore_t openSemafor;
+@property dispatch_semaphore_t closeSemafor;
+@property dispatch_semaphore_t ptpSemafor;
+@property NSData *ptpResponse;
+@property NSData *ptpInput;
+@property NSMutableArray *events;
+@end

--- a/indigo_drivers/ccd_ptp/indigo_ptp_nikon.c
+++ b/indigo_drivers/ccd_ptp/indigo_ptp_nikon.c
@@ -718,7 +718,9 @@ static void ptp_check_event(indigo_device *device) {
 			buffer = NULL;
 		}
 	}
-	indigo_reschedule_timer(device, 1, &PRIVATE_DATA->event_checker);
+	if (IS_CONNECTED) {
+		indigo_reschedule_timer(device, 1, &PRIVATE_DATA->event_checker);
+	}
 }
 
 bool ptp_nikon_initialise(indigo_device *device) {

--- a/indigo_drivers/ccd_ptp/indigo_ptp_nikon.m
+++ b/indigo_drivers/ccd_ptp/indigo_ptp_nikon.m
@@ -20,9 +20,9 @@
 // 2.0 by Peter Polakovic <peter.polakovic@cloudmakers.eu>
 
 /** INDIGO PTP DSLR driver - ICA bridge
- \file indigo_ccd_ptp.m
+ \file indigo_ptp_nikon.m
  */
 
 #define USE_ICA_TRANSPORT
 
-#import "indigo_ccd_ptp.c"
+#import "indigo_ptp_nikon.c"

--- a/indigo_drivers/ccd_ptp/indigo_ptp_sony.c
+++ b/indigo_drivers/ccd_ptp/indigo_ptp_sony.c
@@ -677,6 +677,9 @@ uint8_t *ptp_sony_decode_property(uint8_t *source, indigo_device *device) {
 }
 
 static void ptp_check_event(indigo_device *device) {
+#ifdef USE_ICA_TRANSPORT
+	ptp_get_event(device);
+#else
 	ptp_container event;
 	int length = 0;
 	memset(&event, 0, sizeof(event));
@@ -686,6 +689,7 @@ static void ptp_check_event(indigo_device *device) {
 		PTP_DUMP_CONTAINER(&event);
 		PRIVATE_DATA->handle_event(device, event.code, event.payload.params);
 	}
+#endif
 	indigo_reschedule_timer(device, 0, &PRIVATE_DATA->event_checker);
 }
 

--- a/indigo_drivers/ccd_ptp/indigo_ptp_sony.c
+++ b/indigo_drivers/ccd_ptp/indigo_ptp_sony.c
@@ -690,7 +690,9 @@ static void ptp_check_event(indigo_device *device) {
 		PRIVATE_DATA->handle_event(device, event.code, event.payload.params);
 	}
 #endif
-	indigo_reschedule_timer(device, 0, &PRIVATE_DATA->event_checker);
+	if (IS_CONNECTED) {
+		indigo_reschedule_timer(device, 0, &PRIVATE_DATA->event_checker);
+	}
 }
 
 bool ptp_sony_initialise(indigo_device *device) {

--- a/indigo_drivers/ccd_ptp/indigo_ptp_sony.m
+++ b/indigo_drivers/ccd_ptp/indigo_ptp_sony.m
@@ -20,9 +20,9 @@
 // 2.0 by Peter Polakovic <peter.polakovic@cloudmakers.eu>
 
 /** INDIGO PTP DSLR driver - ICA bridge
- \file indigo_ccd_ptp.m
+ \file indigo_ptp_sony.m
  */
 
 #define USE_ICA_TRANSPORT
 
-#import "indigo_ccd_ptp.c"
+#import "indigo_ptp_sony.c"

--- a/indigo_libs/indigo_timer.c
+++ b/indigo_libs/indigo_timer.c
@@ -276,17 +276,17 @@ bool indigo_cancel_timer_sync(indigo_device *device, indigo_timer **timer) {
 			INDIGO_TRACE(indigo_trace("timer #%d - cancel requested", (*timer)->timer_id));
 			(*timer)->canceled = true;
 			(*timer)->scheduled = false;
+      timer_buffer = *timer;
+      must_wait = true;
 			pthread_mutex_lock(&(*timer)->mutex);
 			pthread_cond_signal(&(*timer)->cond);
 			pthread_mutex_unlock(&(*timer)->mutex);
 			/* Save a local copy of the timer instance as *timer can be set
 			 to NULL by *timer_func() after cancel_timer_mutex is released */
-			timer_buffer = *timer;
-			must_wait = true;
 		}
 	}
 	pthread_mutex_unlock(&cancel_timer_mutex);
-	/* if must_wain == true then timer_buffer != NULL (see above) */
+	/* if must_wait == true then timer_buffer != NULL (see above) */
 	if (must_wait) {
 		INDIGO_TRACE(indigo_trace("timer #%d - waiting to finish", timer_buffer->timer_id));
 		/* just wait for the callback to finish */

--- a/indigo_mac_drivers/ccd_ica/indigo_ccd_ica.m
+++ b/indigo_mac_drivers/ccd_ica/indigo_ccd_ica.m
@@ -947,6 +947,7 @@ static indigo_result focuser_detach(indigo_device *device) {
       free(PRIVATE_DATA->dslr_properties);
 		free(PRIVATE_DATA);
 		free(device);
+		camera.userData = nil;
 	}
 }
 


### PR DESCRIPTION
PTP on macOS may use ICA instead of libusb for smoother coexistence with other ICA based applications.