### PR TITLE
ccd_ptp: Implement focusing for Sony cameras via NearFar

### DIFF
--- a/indigo_drivers/ccd_ptp/indigo_ccd_ptp.c
+++ b/indigo_drivers/ccd_ptp/indigo_ccd_ptp.c
@@ -584,7 +584,7 @@ static indigo_device *attach_device(int vendor, int product, const char *usb_pat
 				private_data->lock = NULL;
 				private_data->af = ptp_sony_af;
 				private_data->zoom = NULL;
-				private_data->focus = NULL;
+				private_data->focus = (CAMERA[i].flags && ptp_flag_lv) ? ptp_sony_focus : NULL;
 				private_data->set_host_time = NULL;
 				private_data->check_dual_compression = ptp_sony_check_dual_compression;
 			} else if (vendor == FUJI_VID) {

--- a/indigo_drivers/ccd_ptp/indigo_ptp_sony.c
+++ b/indigo_drivers/ccd_ptp/indigo_ptp_sony.c
@@ -85,6 +85,7 @@ char *ptp_property_sony_code_name(uint16_t code) {
 		case ptp_property_sony_Zoom: return "Zoom_Sony";
 		case ptp_property_sony_ZoomState: return "ADV_ZoomState";
 		case ptp_property_sony_ZoomRatio: return "ADV_ZoomRatio";
+		case ptp_property_sony_NearFar: return "NearFar";
 		case ptp_property_sony_ExposureCompensation: return "ADV_ExposureCompensation";
 		case ptp_property_sony_SensorCrop: return "ADV_SensorCrop";
 	}
@@ -114,6 +115,7 @@ char *ptp_property_sony_code_label(uint16_t code) {
 		case ptp_property_sony_StillImage: return "Still Image";
 		case ptp_property_sony_PCRemoteSaveDest: return "PC Remote Save Destination";
 		case ptp_property_sony_ExposureCompensation: return "Exposure compensation";
+		case ptp_property_sony_NearFar: return "Near/Far Manual Focus Adjustment";
 		case ptp_property_sony_ZoomState: return "Zoom State";
 		case ptp_property_sony_ZoomRatio: return "Zoom Ratio";
 	}
@@ -1032,6 +1034,69 @@ bool ptp_sony_af(indigo_device *device) {
 		}
 	}
 	return false;
+}
+
+bool ptp_sony_focus(indigo_device *device, int steps) {
+	static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+	if (steps == 0) {
+		pthread_mutex_lock(&mutex);
+		SONY_PRIVATE_DATA->steps = 0;
+		pthread_mutex_unlock(&mutex);
+		return true;
+	} else {
+		bool temporary_lv = true;
+		bool result = false;
+		if (CCD_STREAMING_PROPERTY->state == INDIGO_BUSY_STATE) {
+			temporary_lv = false;
+		} else if (PRIVATE_DATA->model.product == 0x0ccc && !SONY_PRIVATE_DATA->did_liveview) {
+			// This part is copied from ptp_sony_set_property
+			// A7R4 needs 3s delay before first capture
+			INDIGO_DRIVER_DEBUG(DRIVER_NAME, "3s delay...");
+			for (int i = 0; i < 30; i++) {
+				if (PRIVATE_DATA->abort_capture)
+					return false;
+				indigo_usleep(100000);
+			}
+			pthread_mutex_lock(&mutex);
+			SONY_PRIVATE_DATA->did_liveview = true;
+			SONY_PRIVATE_DATA->did_capture = false;
+			pthread_mutex_unlock(&mutex);
+		}
+		pthread_mutex_lock(&mutex);
+		SONY_PRIVATE_DATA->steps = steps;
+		pthread_mutex_unlock(&mutex);
+		bool run = true;
+		// This apparently should be run once, but it doesn't seem to be necessary
+		uint16_t set_manual = 1;
+		if (!ptp_transaction_0_1_o(device, ptp_operation_sony_SetControlDeviceB, 0xD2D2, &set_manual, sizeof(uint16_t)))
+			run = false;
+		while (run) {
+			if (SONY_PRIVATE_DATA->steps == 0) {
+				result = true;
+				break;
+			}
+			int16_t value = SONY_PRIVATE_DATA->steps < 0 ? -2 : 2;
+			if (SONY_PRIVATE_DATA->steps < 0) {
+				pthread_mutex_lock(&mutex);
+				SONY_PRIVATE_DATA->steps++;
+				pthread_mutex_unlock(&mutex);
+			} else if (SONY_PRIVATE_DATA->steps > 0) {
+				pthread_mutex_lock(&mutex);
+				SONY_PRIVATE_DATA->steps--;
+				pthread_mutex_unlock(&mutex);
+			}
+			if (!ptp_transaction_0_1_o(device, ptp_operation_sony_SetControlDeviceB, ptp_property_sony_NearFar, &value, sizeof(uint16_t))
+)
+				break;
+			indigo_usleep(50000);
+		}
+		if (temporary_lv) {
+			pthread_mutex_lock(&mutex);
+			SONY_PRIVATE_DATA->did_liveview=true;
+			pthread_mutex_unlock(&mutex);
+		}
+		return result;
+	}
 }
 
 bool ptp_sony_check_dual_compression(indigo_device *device) {

--- a/indigo_drivers/ccd_ptp/indigo_ptp_sony.h
+++ b/indigo_drivers/ccd_ptp/indigo_ptp_sony.h
@@ -68,6 +68,7 @@ typedef enum {
 	ptp_property_sony_Capture = 0xD2C2,
 	ptp_property_sony_Movie = 0xD2C8,
 	ptp_property_sony_StillImage = 0xD2C7,
+	ptp_property_sony_NearFar = 0xD2D1,
 	ptp_property_sony_ZoomState = 0xD22D,
 	ptp_property_sony_ZoomRatio = 0xD22F,
 } ptp_property_sony_code;
@@ -80,6 +81,7 @@ typedef struct {
 	bool is_dual_compression;
 	bool did_capture;
 	bool did_liveview;
+	int steps;
 } sony_private_data;
 
 
@@ -95,6 +97,7 @@ extern bool ptp_sony_set_property(indigo_device *device, ptp_property *property)
 extern bool ptp_sony_exposure(indigo_device *device);
 extern bool ptp_sony_liveview(indigo_device *device);
 extern bool ptp_sony_af(indigo_device *device);
+extern bool ptp_sony_focus(indigo_device *device, int steps);
 extern bool ptp_sony_check_dual_compression(indigo_device *device);
 
 #endif /* indigo_ptp_sony_h */


### PR DESCRIPTION
This pull request aims to implement a focuser for Sony cameras, similar to the existing one for Canon. This is done through the use of the property NearFar, which is also added to the property list.

The focusing routine is modified from the Canon one. I have done some simple testing with a Sony A7R III and Sony 200-600 lens in AIN by sending relative focus commands, and can confirm via the images and the back screen of the camera that it does shift focus. That said, I have not tested this with the full focusing routine as I don't have the ability to try this under the stars yet.