### PR TITLE
fix crash issue on windows

### DIFF
--- a/indigo_libs/indigo_client.c
+++ b/indigo_libs/indigo_client.c
@@ -381,7 +381,11 @@ static void *server_thread(indigo_server_entry *server) {
 			inet_ntop(AF_INET, &((struct sockaddr_in *)address->ai_addr)->sin_addr, text, sizeof(text));
 #endif
 			if (result < 0) {
+#if defined(INDIGO_WINDOWS)
+				closesocket(server->socket);
+#else
 				close(server->socket);
+#endif
 				server->socket = -1;
 				INDIGO_LOG(indigo_log("Can't connect to socket %s:%d (%s)", text, ntohs(((struct sockaddr_in *)address->ai_addr)->sin_port), strerror(errno)));
 				strncpy(server->last_error, strerror(errno), sizeof(server->last_error));


### PR DESCRIPTION
On windows, `close(server->socket)` should be `closesocket(server->socket)`.

same as: https://github.com/indigo-astronomy/indigo/blob/a86c08f1d46d46806a2690dc5710cac4563d7afc/indigo_libs/indigo_client.c#L417-L421
