### PR TITLE
ccd_ptp driver lacks the CCD Frame Property

### DIFF
--- a/indigo_drivers/ccd_ptp/indigo_ccd_ptp.c
+++ b/indigo_drivers/ccd_ptp/indigo_ccd_ptp.c
@@ -62,7 +62,10 @@ static indigo_result ccd_attach(indigo_device *device) {
 		// --------------------------------------------------------------------------------
 		CCD_MODE_PROPERTY->hidden = true;
 		CCD_STREAMING_PROPERTY->hidden = PRIVATE_DATA->liveview == NULL;
-		CCD_FRAME_PROPERTY->hidden = true;
+		CCD_FRAME_PROPERTY->perm = INDIGO_RO_PERM;
+		CCD_FRAME_WIDTH_ITEM->number.value = PRIVATE_DATA->model.width;
+		CCD_FRAME_HEIGHT_ITEM->number.value = PRIVATE_DATA->model.height;
+		CCD_FRAME_BITS_PER_PIXEL_ITEM->number.value = 16;
 		CCD_INFO_WIDTH_ITEM->number.value = PRIVATE_DATA->model.width;
 		CCD_INFO_HEIGHT_ITEM->number.value = PRIVATE_DATA->model.height;
 		CCD_INFO_PIXEL_WIDTH_ITEM->number.value = CCD_INFO_PIXEL_HEIGHT_ITEM->number.value =  CCD_INFO_PIXEL_SIZE_ITEM->number.value = PRIVATE_DATA->model.pixel_size;


### PR DESCRIPTION
The comment of the CCD_FRAME property definition says

> property is mandatory, should be set read-only if subframe can't be set

Indeed, the CCD Ciel client doesn't recognise my DSLR as a camera, because of this property absence.
This pull request applies the above recommendation, making it read-only instead of hidden.