### PR TITLE
ccd_ptp: fix retry sequence for FUJIFILM X-Pro3

### DIFF
--- a/indigo_drivers/ccd_ptp/indigo_ptp_fuji.c
+++ b/indigo_drivers/ccd_ptp/indigo_ptp_fuji.c
@@ -702,6 +702,7 @@ bool ptp_fuji_liveview(indigo_device *device) {
 					ptp_transaction_1_0(device, ptp_operation_TerminateOpenCapture, FUJI_LIVEVIEW_HANDLE);
 					return false;
 				}
+				indigo_usleep(100000);  // 100ms
 				continue;
 			}
 			source = ptp_decode_uint32(source, &handle);


### PR DESCRIPTION
X-Pro3 liveview always fails after the first frame.

I fixed the sequence of the retry loop.
