### PR TITLE
indigo_stod(): constify format parameter

### DIFF
--- a/indigo_libs/indigo/indigo_bus.h
+++ b/indigo_libs/indigo/indigo_bus.h
@@ -727,7 +727,7 @@ extern double indigo_stod(char *string);
 
 /** Convert double to sexagesimal string.
  */
-extern char* indigo_dtos(double value, char *format);
+extern char* indigo_dtos(double value, const char *format);
 
 /** Sleeps for specified number of microseconds.
  */

--- a/indigo_libs/indigo_bus.c
+++ b/indigo_libs/indigo_bus.c
@@ -1852,7 +1852,7 @@ static void fix_dms(double *d, double *m, double *s) {
 	}
 }
 
-char* indigo_dtos(double value, char *format) { // circular use of 4 static buffers!
+char* indigo_dtos(double value, const char *format) { // circular use of 4 static buffers!
 	double d = fabs(value);
 	double m = 60.0 * (d - floor(d));
 	double s = 60.0 * (m - floor(m));
@@ -1861,7 +1861,8 @@ char* indigo_dtos(double value, char *format) { // circular use of 4 static buff
 	}
 	char buffer[127], signature[16];
 	// compute format signature
-	char *fp = format, *sp = signature;
+	const char *fp = format;
+	char *sp = signature;
 	while (*fp && sp - signature < sizeof(signature) - 1) {
 		if (*fp == '%') {
 			fp++;


### PR DESCRIPTION
This should fix a good number of warnings (about const qualifier being dropped on strings) I see when building eg. the ain_imager or other applications supplying a format string.