### PR TITLE
Constify indigo_get_item() and indigo_get_switch()

### DIFF
--- a/indigo_libs/indigo/indigo_bus.h
+++ b/indigo_libs/indigo/indigo_bus.h
@@ -599,11 +599,11 @@ extern void indigo_set_switch(indigo_property *property, indigo_item *item, bool
 
 /** Get item.
  */
-extern indigo_item *indigo_get_item(indigo_property *property, char *item_name);
+extern indigo_item *indigo_get_item(indigo_property *property, const char *item_name);
 
 /** Get switch item value.
  */
-extern bool indigo_get_switch(indigo_property *property, char *item_name);
+extern bool indigo_get_switch(indigo_property *property, const char *item_name);
 
 /** Copy item values from other property into property (optionally including property state).
  */

--- a/indigo_libs/indigo_bus.c
+++ b/indigo_libs/indigo_bus.c
@@ -1461,7 +1461,7 @@ void indigo_set_switch(indigo_property *property, indigo_item *item, bool value)
 	item->sw.value = value;
 }
 
-indigo_item *indigo_get_item(indigo_property *property, char *item_name) {
+indigo_item *indigo_get_item(indigo_property *property, const char *item_name) {
 	assert(property != NULL);
 	assert(item_name != NULL);
 	for (int i = 0; i < property->count; i++)
@@ -1470,7 +1470,7 @@ indigo_item *indigo_get_item(indigo_property *property, char *item_name) {
 	return NULL;
 }
 
-bool indigo_get_switch(indigo_property *property, char *item_name) {
+bool indigo_get_switch(indigo_property *property, const char *item_name) {
 	assert(property != NULL);
 	assert(property->type == INDIGO_SWITCH_VECTOR);
 	assert(item_name != NULL);


### PR DESCRIPTION
These are two more functions that don't need a supplied writeable string. (Maybe more to come, I'm working on ain_imager right now.)