### PR TITLE
use correct port 9999 for onstep tcp connection

### DIFF
--- a/indigo_drivers/mount_lx200/indigo_mount_lx200.c
+++ b/indigo_drivers/mount_lx200/indigo_mount_lx200.c
@@ -279,7 +279,7 @@ static bool meade_open(indigo_device *device) {
 	} else {
 		PRIVATE_DATA->is_network = true;
 		indigo_network_protocol proto = INDIGO_PROTOCOL_TCP;
-		if (MOUNT_TYPE_NYX_ITEM->sw.value)
+		if (MOUNT_TYPE_NYX_ITEM->sw.value || MOUNT_TYPE_ON_STEP_ITEM->sw.value)
 			PRIVATE_DATA->handle = indigo_open_network_device(name, 9999, &proto);
 		else
 			PRIVATE_DATA->handle = indigo_open_network_device(name, 4030, &proto);


### PR DESCRIPTION
OnStep also uses port 9999 by default

See:
https://onstep.groups.io/g/main/wiki/3863/18319
