### PR TITLE
fix compiler warnings for ccd_ptp

### DIFF
--- a/indigo_drivers/ccd_ptp/indigo_ptp_canon.c
+++ b/indigo_drivers/ccd_ptp/indigo_ptp_canon.c
@@ -564,7 +564,7 @@ char *ptp_property_canon_value_code_label(indigo_device *device, uint16_t proper
 					strcpy(label, "CR2 + ");
 					break;
 				default:
-					sprintf(label, "Unknown (0x%llx) +", (code >> 32) & 0xFFFFFFFF);
+					sprintf(label, "Unknown (0x%llx) +", (unsigned long long) (code >> 32) & 0xFFFFFFFF);
 					break;
 			}
 			switch (code & 0xFFFFFFFF) {
@@ -656,7 +656,8 @@ char *ptp_property_canon_value_code_label(indigo_device *device, uint16_t proper
 					strcat(label, "CR2");
 					break;
 				default:
-					sprintf(label, "%sUnknown (0x%llx)", label, code & 0xFFFFFFFF);
+					size_t len = strlen(label);
+					snprintf(label + len, sizeof(label) - len, "Unknown (0x%llx)", (unsigned long long)code & 0xFFFFFFFF);
 					break;
 			}
 			return label;
@@ -989,7 +990,7 @@ static void ptp_canon_get_event(indigo_device *device) {
 							break;
 						}
 						case ptp_str_type: {
-							strncpy((char *)property->value.text.value, (char *)source, PTP_MAX_CHARS);
+							indigo_safe_strncpy((char *)property->value.text.value, (char *)source, PTP_MAX_CHARS);
 							break;
 						}
 						case ptp_undef_type: {
@@ -1147,9 +1148,9 @@ static void ptp_canon_get_event(indigo_device *device) {
 					ptp_decode_uint32(source, &handle);
 					ptp_decode_uint32(source + 0x14, &length);
 					if (event == ptp_event_canon_ObjectAddedEx) {
-						strncpy(filename, (char *)source + 0x20, PTP_MAX_CHARS);
+						indigo_safe_strncpy(filename, (char *)source + 0x20, PTP_MAX_CHARS);
 					} else {
-						strncpy(filename, (char *)source + 0x24, PTP_MAX_CHARS);
+						indigo_safe_strncpy(filename, (char *)source + 0x24, PTP_MAX_CHARS);
 					}
 					if (CCD_UPLOAD_MODE_NONE_ITEM->sw.value) {
 						INDIGO_DRIVER_LOG(DRIVER_NAME, "%s (%04x): handle = %08x, size = %u, name = '%s' skipped", ptp_event_canon_code_label(event), event, handle, length, filename);
@@ -1383,7 +1384,7 @@ static bool set_number_property(indigo_device *device, uint16_t code, uint64_t v
 
 static bool set_string_property(indigo_device *device, uint16_t code, char *value) {
 	uint8_t buffer[PTP_MAX_CHARS + 2 * sizeof(uint32_t)], *target = buffer + 2 * sizeof(uint32_t);
-	strncpy((char *)target, value, PTP_MAX_CHARS);
+	indigo_safe_strncpy((char *)target, value, PTP_MAX_CHARS);
 	target += strlen((char *)target) + 1;
 	uint32_t size = *((uint32_t *)buffer) = (uint32_t)(target - buffer);
 	*((uint32_t *)buffer + 1) = code;

--- a/indigo_drivers/ccd_ptp/indigo_ptp_nikon.c
+++ b/indigo_drivers/ccd_ptp/indigo_ptp_nikon.c
@@ -686,7 +686,7 @@ char *ptp_property_nikon_value_code_label(indigo_device *device, uint16_t proper
 		}
 		case ptp_property_nikon_ExposureIndexHi: {
 			// same as ptp_property_ExposureIndex
-			sprintf(label, "%lld", code);
+			sprintf(label, "%lld", (unsigned long long) code);
 			return label;
 		}
 		case ptp_property_nikon_ExposureTime: {
@@ -705,7 +705,7 @@ char *ptp_property_nikon_value_code_label(indigo_device *device, uint16_t proper
 			} else if (numerator == 10) {
 				snprintf(label, PTP_MAX_CHARS,  "1/%.1fs", denominator / 10.0);
 			} else {
-				snprintf(label, PTP_MAX_CHARS,  "0x%llx", code);
+				snprintf(label, PTP_MAX_CHARS,  "0x%llx", (unsigned long long) code);
 			}
 			return label;
 		}

--- a/indigo_libs/indigo/indigo_bus.h
+++ b/indigo_libs/indigo/indigo_bus.h
@@ -753,8 +753,8 @@ extern void indigo_set_text_item_value(indigo_item *item, const char *value);
 
 #define indigo_fix_locale(s) { char *fc = strchr(s, ','); if (fc) *fc = '.'; }
 
-#define indigo_copy_name(target, source) { memset(target, 0, INDIGO_NAME_SIZE); strncpy(target, source, INDIGO_NAME_SIZE - 1); }
-#define indigo_copy_value(target, source) { memset(target, 0, INDIGO_VALUE_SIZE); strncpy(target, source, INDIGO_VALUE_SIZE - 1); }
+#define indigo_copy_name(target, source) { memset(target, 0, INDIGO_NAME_SIZE); indigo_safe_strncpy(target, source, INDIGO_NAME_SIZE - 1); }
+#define indigo_copy_value(target, source) { memset(target, 0, INDIGO_VALUE_SIZE); indigo_safe_strncpy(target, source, INDIGO_VALUE_SIZE - 1); }
 
 #define indigo_define_matching_property(template); if (indigo_property_match(template, property)) indigo_define_property(device, template, NULL)
 
@@ -837,13 +837,20 @@ static inline void indigo_safe_free(void *pointer) {
 		free(pointer);
 	}
 }
-
+/**
+ * Copy null-terminated string from src to dst, stopping after size characters
+ * Returns a pointer to the next byte in dst after inserting or NULL if either size is NULL or truncation occured
+ */
 static inline char *indigo_safe_strncpy(char *dst, const char *src, size_t size) {
-    if (size > 0) {
-		dst[size - 1] = '\0';
-        strncpy(dst, src, size - 1);
-    }
-	return dst;
+	if (size == 0) {
+        return NULL;
+	}
+	char *c = (char *) memccpy(dst, src, '\0', size);
+	if (c == NULL) {
+		dst[size - 1] = '\0'; /* truncation occured, null-terminate manually. */
+		return NULL;
+	}
+	return c;
 }
 
 #define INDIGO_BUFFER_SIZE (128 * 1024)


### PR DESCRIPTION
This fixes compiler warnings in ccd_ptp, now it compiles with -Wall on gcc 12.

Also the indigo_safe_strncpy function is improved, it should feature more performance and generate less warnings.
(See: https://nrk.neocities.org/articles/not-a-fan-of-strlcpy) 

