### PR TITLE
deleting redundant MOUNT_ALIGNMENT_DELETE_POINTS_PROPERTY_NAME

### DIFF
--- a/indigo_libs/indigo/indigo_names.h
+++ b/indigo_libs/indigo/indigo_names.h
@@ -1869,12 +1869,6 @@
 /** MOUNT_SIDE_OF_PIER.WEST property item name.
  */
 #define MOUNT_SIDE_OF_PIER_WEST_ITEM_NAME             		"WEST"
-
-//----------------------------------------------------------------------
-/** MOUNT_ALIGNMENT_DELETE_POINTS property name.
- */
-#define MOUNT_ALIGNMENT_DELETE_POINTS_PROPERTY_NAME	"MOUNT_ALIGNMENT_DELETE_POINTS"
-
 //----------------------------------------------------------------------
 /** MOUNT_PEC property name.
  */


### PR DESCRIPTION
The `MOUNT_ALIGNMENT_DELETE_POINTS_PROPERTY_NAME` property is defined twice, suggest we delete one `#define` statement.