### PR TITLE
Rename `DELTA_UTC_UT1` in `DELTA_UT1_UTC`

### DIFF
--- a/indigo_drivers/mount_ioptron/indigo_mount_ioptron.c
+++ b/indigo_drivers/mount_ioptron/indigo_mount_ioptron.c
@@ -312,7 +312,7 @@ static bool ieq_get_utc(indigo_device *device, time_t *secs, int *utc_offset) {
 			int offset = atoi(response);
 			*utc_offset = offset / 60;
 			double jd = atoll(response + 5) / 8.64e+7 + JD2000;
-			*secs = (jd - DELTA_UTC_UT1 - 2440587.5) * 86400.0;
+			*secs = (jd - DELTA_UT1_UTC - 2440587.5) * 86400.0;
 			return true;
 		}
 	}

--- a/indigo_libs/indigo/indigo_align.h
+++ b/indigo_libs/indigo/indigo_align.h
@@ -51,8 +51,8 @@ extern const double RAD2DEG;
 #define JD2000           2451545.0
 
 #ifndef UT2JD
-#define DELTA_UTC_UT1 (0.0340990 / 86400.0) /* For 2025-04-19 */
-#define UT2JD(t)         ((t) / 86400.0 + 2440587.5 + DELTA_UTC_UT1)
+#define DELTA_UT1_UTC (0.0340990 / 86400.0) /* For 2025-04-19 */
+#define UT2JD(t)         ((t) / 86400.0 + 2440587.5 + DELTA_UT1_UTC)
 #define JDNOW            UT2JD(time(NULL))
 #endif /* UT2JD */
 

--- a/indigo_libs/indigo/indigo_driver.h
+++ b/indigo_libs/indigo/indigo_driver.h
@@ -50,8 +50,8 @@
 #endif
 
 #ifndef UT2JD
-#define DELTA_UTC_UT1 (0.0340990 / 86400.0) /* For 2025-04-19 */
-#define UT2JD(t)         ((t) / 86400.0 + 2440587.5 + DELTA_UTC_UT1)
+#define DELTA_UT1_UTC (0.0340990 / 86400.0) /* For 2025-04-19 */
+#define UT2JD(t)         ((t) / 86400.0 + 2440587.5 + DELTA_UT1_UTC)
 #define JDNOW            UT2JD(time(NULL))
 #endif
 

--- a/indigo_libs/indigocat/example/planets_test.c
+++ b/indigo_libs/indigocat/example/planets_test.c
@@ -4,8 +4,8 @@
 #include <math.h>
 #include <time.h>
 
-#define DELTA_UTC_UT1 (0.0340990 / 86400.0) /* For 2025-04-19 */
-#define UT2JD(t) ((t) / 86400.0 + 2440587.5 + DELTA_UTC_UT1)
+#define DELTA_UT1_UTC (0.0340990 / 86400.0) /* For 2025-04-19 */
+#define UT2JD(t) ((t) / 86400.0 + 2440587.5 + DELTA_UT1_UTC)
 #define JD_NOW UT2JD(time(NULL))
 
 

--- a/indigo_libs/indigocat/indigocat_ss.c
+++ b/indigo_libs/indigocat/indigocat_ss.c
@@ -32,8 +32,8 @@
 #include <indigo/indigocat/indigocat_solar_system.h>
 #include <indigo/indigocat/indigocat_ss.h>
 
-#define DELTA_UTC_UT1 (0.0340990 / 86400.0) /* For 2025-04-19 */
-#define UT2JD(t) 			((t) / 86400.0 + 2440587.5 + DELTA_UTC_UT1)
+#define DELTA_UT1_UTC (0.0340990 / 86400.0) /* For 2025-04-19 */
+#define UT2JD(t) 			((t) / 86400.0 + 2440587.5 + DELTA_UT1_UTC)
 #define JDNOW 				UT2JD(time(NULL))
 
 static indigocat_ss_entry indigo_ss_data[] = {

--- a/tools/update_DELTA_UT1_UTC.sh
+++ b/tools/update_DELTA_UT1_UTC.sh
@@ -10,17 +10,17 @@ LATEST_MEASURED_LINE="$(curl -s "$DATA_SOURCE" | awk -F ';' '$14 == "final" {las
 YEAR="$(echo "$LATEST_MEASURED_LINE" | awk -F ';' '{print $2}')"
 MONTH="$(echo "$LATEST_MEASURED_LINE" | awk -F ';' '{print $3}')"
 DAY="$(echo "$LATEST_MEASURED_LINE" | awk -F ';' '{print $4}')"
-DELTA_UTC_UT1="$(echo "$LATEST_MEASURED_LINE" | awk -F ';' '{print $15}')"
+DELTA_UT1_UTC="$(echo "$LATEST_MEASURED_LINE" | awk -F ';' '{print $15}')"
 
-echo "DELTA_UTC_UT1 = $DELTA_UTC_UT1 for date $YEAR-$MONTH-$DAY"
+echo "DELTA_UT1_UTC = $DELTA_UT1_UTC for date $YEAR-$MONTH-$DAY"
 
-if ! echo "$DELTA_UTC_UT1" | grep -Eq '^-?[0-9]+(\.[0-9]+)?$'; then
-	echo "Error: DELTA_UTC_UT1 is not a valid number: $DELTA_UTC_UT1"
+if ! echo "$DELTA_UT1_UTC" | grep -Eq '^-?[0-9]+(\.[0-9]+)?$'; then
+	echo "Error: DELTA_UT1_UTC is not a valid number: $DELTA_UT1_UTC"
 	exit 1
 fi
 
-if (( $(echo "$DELTA_UTC_UT1 < -1 || $DELTA_UTC_UT1 > 1" | bc -l) )); then
-	echo "Error: DELTA_UTC_UT1 is out of the expected range (-1 to 1): $DELTA_UTC_UT1"
+if (( $(echo "$DELTA_UT1_UTC < -1 || $DELTA_UT1_UTC > 1" | bc -l) )); then
+	echo "Error: DELTA_UT1_UTC is out of the expected range (-1 to 1): $DELTA_UT1_UTC"
 	exit 1
 fi
 
@@ -29,10 +29,10 @@ for file in \
 		indigo_libs/indigo/indigo_driver.h \
 		indigo_libs/indigocat/indigocat_ss.c \
 		indigo_libs/indigocat/example/planets_test.c; do
-	if ! sed -i "s%#define DELTA_UTC_UT1.*%#define DELTA_UTC_UT1 ($DELTA_UTC_UT1 / 86400.0) /* For $YEAR-$MONTH-$DAY */%g" "$file"; then
+	if ! sed -i "s%#define DELTA_UT1_UTC.*%#define DELTA_UT1_UTC ($DELTA_UT1_UTC / 86400.0) /* For $YEAR-$MONTH-$DAY */%g" "$file"; then
 		echo "Error: Failed to update $file"
 		exit 1
 	fi
 done
 
-echo "DELTA_UTC_UT1 successfully updated"
+echo "DELTA_UT1_UTC successfully updated"


### PR DESCRIPTION
This pull request aims to clarify the name of the variable `DELTA_UTC_UT1`.

With that name, the variable seems to represent the difference UTC-UT1, while in reality it represents the opposite UT1-UTC. Also, the standard name used for this variable is `DUT1` (see [IERS Bulletin D](https://datacenter.iers.org/products/eop/bulletind/bulletind.dat)), while other programs or libraries use more extended versions like `DELTA_UT1` (like in [MATLAB](https://www.mathworks.com/help/aeroblks/deltaut1.html)) or `DELTA_UT1_UTC` (like in [Astropy](https://docs.astropy.org/en/stable/api/astropy.time.Time.html#astropy.time.Time.delta_ut1_utc)).

I think that the last name is better since its similar with the one already used.