### PR TITLE
Keep connection during WiFi reset/ reload when tethered

### DIFF
--- a/indigo_drivers/mount_lx200/indigo_mount_lx200.c
+++ b/indigo_drivers/mount_lx200/indigo_mount_lx200.c
@@ -3031,12 +3031,27 @@ static void nyx_cl_callback(indigo_device *device) {
 		}
 		if (meade_command(device, command, response, sizeof(response), 0) && *response == '1') {
 			if (meade_command(device, ":WLC#", NULL, 0, 0)) {
-				PRIVATE_DATA->wifi_reset = true;
-				indigo_send_message(device, "WiFi reset!");
-				NYX_WIFI_CL_PROPERTY->state = INDIGO_OK_STATE;
-				indigo_update_property(device, NYX_WIFI_CL_PROPERTY, NULL);
-				indigo_set_timer(device, 0, network_disconnection, NULL);
-				return;
+				indigo_send_message(device, "WiFi reloading...");
+				if (PRIVATE_DATA->is_network) {
+					PRIVATE_DATA->wifi_reset = true;
+					NYX_WIFI_CL_PROPERTY->state = INDIGO_OK_STATE;
+					indigo_update_property(device, NYX_WIFI_CL_PROPERTY, NULL);
+					indigo_set_timer(device, 0, network_disconnection, NULL);
+					indigo_safe_free(encoded);
+					return;
+				} else {
+					for (int i = 0; i < 20; i++) {
+						indigo_usleep(ONE_SECOND_DELAY);
+						if (meade_command(device, ":WLI#", response, sizeof(response), 0)
+						    && !strncmp(response, NYX_WIFI_CL_SSID_ITEM->text.value, strlen(NYX_WIFI_CL_SSID_ITEM->text.value))) {
+							indigo_send_message(device, "Connected to %s", NYX_WIFI_CL_SSID_ITEM->text.value);
+							NYX_WIFI_CL_PROPERTY->state = INDIGO_OK_STATE;
+							indigo_update_property(device, NYX_WIFI_CL_PROPERTY, NULL);
+							indigo_safe_free(encoded);
+							return;
+						}
+					}
+				}
 			}
 		}
 	}
@@ -3047,11 +3062,13 @@ static void nyx_cl_callback(indigo_device *device) {
 
 static void nyx_reset_callback(indigo_device *device) {
 	if (meade_command(device, ":WLZ#", NULL, 0, 0)) {
-		PRIVATE_DATA->wifi_reset = true;
 		indigo_send_message(device, "WiFi reset!");
 		NYX_WIFI_RESET_PROPERTY->state = INDIGO_OK_STATE;
 		indigo_update_property(device, NYX_WIFI_RESET_PROPERTY, NULL);
-		indigo_set_timer(device, 0, network_disconnection, NULL);
+		if (PRIVATE_DATA->is_network) {
+			PRIVATE_DATA->wifi_reset = true;
+			indigo_set_timer(device, 0, network_disconnection, NULL);
+		}
 		return;
 	}
 	NYX_WIFI_RESET_PROPERTY->state = INDIGO_ALERT_STATE;
@@ -4026,11 +4043,12 @@ static indigo_device *mount_focuser = NULL;
 static indigo_device *mount_aux = NULL;
 
 static void network_disconnection(__attribute__((unused)) indigo_device* device) {
-	// Since all three devices share the same TCP connection,
-	// process the disconnection on all three of them
+	// Since all four devices share the same TCP connection,
+	// process the disconnection on all of them
 	device_network_disconnection(mount, mount_connect_callback);
 	device_network_disconnection(mount_guider, guider_connect_callback);
 	device_network_disconnection(mount_focuser, focuser_connect_callback);
+	device_network_disconnection(mount_aux, aux_connect_callback);
 }
 
 indigo_result indigo_mount_lx200(indigo_driver_action action, indigo_driver_info *info) {


### PR DESCRIPTION
The last commit on WiFi reset makes sense when the connection to the NYX mount uses the WiFi, but it removed the capacity to monitor the WiFi change success (or failure) when the device connection is tethered on USB.
I propose this PR in order not to disconnect when the connection is tethered.

By the way, I fixed a couple of minor issues : the disconnection callback forgot the aux device, and the wifi client callback had a small memory leak.