### PR TITLE
ccd_asi: correction about binning size (BREAKING CHANGE)

### DIFF
--- a/indigo_drivers/ccd_asi/indigo_ccd_asi.c
+++ b/indigo_drivers/ccd_asi/indigo_ccd_asi.c
@@ -793,8 +793,8 @@ static indigo_result ccd_attach(indigo_device *device) {
 			int binned_height = CCD_FRAME_HEIGHT_ITEM->number.value / bin;
 			// ASISetROIFormat docs says:
 			// Note: In general make sure iWidth%8=0，iHeight%2=0.
-			binned_width = binned_width % 8;
-			binned_height = binned_height % 2;
+			binned_width -= binned_width % 8;
+			binned_height -= binned_height % 2;
 			if (pixel_format_supported(device, ASI_IMG_RAW8)) {
 				snprintf(name, 32, "%s %dx%d", RAW8_NAME, bin, bin);
 				snprintf(label, 64, "%s %dx%d", RAW8_NAME, binned_width, binned_height);

--- a/indigo_drivers/ccd_asi/indigo_ccd_asi.c
+++ b/indigo_drivers/ccd_asi/indigo_ccd_asi.c
@@ -789,27 +789,33 @@ static indigo_result ccd_attach(indigo_device *device) {
 		char name[32], label[64];
 		for (int num = 0; (num < 16) && PRIVATE_DATA->info.SupportedBins[num]; num++) {
 			int bin = PRIVATE_DATA->info.SupportedBins[num];
+			int binned_width = CCD_FRAME_WIDTH_ITEM->number.value / bin;
+			int binned_height = CCD_FRAME_HEIGHT_ITEM->number.value / bin;
+			// ASISetROIFormat docs says:
+			// Note: In general make sure iWidth%8=0，iHeight%2=0.
+			binned_width = binned_width % 8;
+			binned_height = binned_height % 2;
 			if (pixel_format_supported(device, ASI_IMG_RAW8)) {
 				snprintf(name, 32, "%s %dx%d", RAW8_NAME, bin, bin);
-				snprintf(label, 64, "%s %dx%d", RAW8_NAME, (int)CCD_FRAME_WIDTH_ITEM->number.value / bin, (int)CCD_FRAME_HEIGHT_ITEM->number.value / bin);
+				snprintf(label, 64, "%s %dx%d", RAW8_NAME, binned_width, binned_height);
 				indigo_init_switch_item(CCD_MODE_PROPERTY->items + mode_count, name, label, bin == 1);
 				mode_count++;
 			}
 			if (pixel_format_supported(device, ASI_IMG_RGB24)) {
 				snprintf(name, 32, "%s %dx%d", RGB24_NAME, bin, bin);
-				snprintf(label, 64, "%s %dx%d", RGB24_NAME, (int)CCD_FRAME_WIDTH_ITEM->number.value / bin, (int)CCD_FRAME_HEIGHT_ITEM->number.value / bin);
+				snprintf(label, 64, "%s %dx%d", RGB24_NAME, binned_width, binned_height);
 				indigo_init_switch_item(CCD_MODE_PROPERTY->items + mode_count, name, label, false);
 				mode_count++;
 			}
 			if (pixel_format_supported(device, ASI_IMG_RAW16)) {
 				snprintf(name, 32, "%s %dx%d", RAW16_NAME, bin, bin);
-				snprintf(label, 64, "%s %dx%d", RAW16_NAME, (int)CCD_FRAME_WIDTH_ITEM->number.value / bin, (int)CCD_FRAME_HEIGHT_ITEM->number.value / bin);
+				snprintf(label, 64, "%s %dx%d", RAW16_NAME, binned_width, binned_height);
 				indigo_init_switch_item(CCD_MODE_PROPERTY->items + mode_count, name, label, false);
 				mode_count++;
 			}
 			if (pixel_format_supported(device, ASI_IMG_Y8)) {
 				snprintf(name, 32, "%s %dx%d", Y8_NAME, bin, bin);
-				snprintf(label, 64, "%s %dx%d", Y8_NAME, (int)CCD_FRAME_WIDTH_ITEM->number.value / bin, (int)CCD_FRAME_HEIGHT_ITEM->number.value / bin);
+				snprintf(label, 64, "%s %dx%d", Y8_NAME, binned_width, binned_height);
 				indigo_init_switch_item(CCD_MODE_PROPERTY->items + mode_count, name, label, false);
 				mode_count++;
 			}


### PR DESCRIPTION
The ASI294MC Pro is currently listed with the following image sizes:

* 4144x2822
* 2072x1411
* 1381x940
* 1036x705

However, the 1381x940 resolution, which is 3x3 binning, will fail to capture the image.

According to the SDK manual (page 9 of the ASICamera2 Software Development Kit.pdf), the binning image size must be a value divisible by 8 for X and divisible by 2 for Y.

> Notes：In general make sure iWidth%8=0，iHeight%2=0.

Following this note, the correct image size is as follows:

* 4144x2822
* 2072x**1410**
* **1376**x940
* **1032**x**704**

**NOTE: This modification will result in a breaking change as it alters the size of the binning image.**
