### PR TITLE
Skip shutter delay for secondary CCD if primary CCD exposure is in progress

### DIFF
--- a/indigo_drivers/ccd_sbig/indigo_ccd_sbig.c
+++ b/indigo_drivers/ccd_sbig/indigo_ccd_sbig.c
@@ -699,7 +699,7 @@ static bool sbig_read_pixels(indigo_device *device) {
 	long wait_cycles = 6000;  /* 6000*2000us = 12s */
 	unsigned char *frame_buffer;
 
-	/* for the exposyre to complete and end it */
+	/* for the exposure to complete and end it */
 	while(!sbig_exposure_complete(device) && wait_cycles--) {
 		usleep(2000);
 	}
@@ -744,6 +744,20 @@ static bool sbig_read_pixels(indigo_device *device) {
 	EndExposureParams eep = {
 		.ccd = srp.ccd
 	};
+	/* Skip end exposure shutter delay for secondary CCD if primary CCD exposure is in progress */
+	if (!PRIMARY_CCD) {
+		unsigned short status;
+		res = get_command_status(CC_START_EXPOSURE2, &status);
+		if (res != CE_NO_ERROR) {
+			INDIGO_DRIVER_ERROR(DRIVER_NAME, "CC_QUERY_COMMAND_STATUS error = %d (%s)", res, sbig_error_string(res));
+			pthread_mutex_unlock(&driver_mutex);
+			return false;
+		}
+		INDIGO_DRIVER_DEBUG(DRIVER_NAME, "Secondary CCD: status = 0x%x", status);
+		if ((status & 2) == 2) { /* Primary CCD exposure is in progress so no need for the shutter delay */
+			eep.ccd |= END_SKIP_DELAY;
+		}		
+	}
 
 	res = sbig_command(CC_END_EXPOSURE, &eep, NULL);
 	if (res != CE_NO_ERROR) {


### PR DESCRIPTION
If the main CCD is exposing while guiding with the secondary CCD of the dual CCD SBIG camera, the shutter delay of the "end exposure" SBIG command for the guiding CCD can be skipped. This removes an unnecessary ~0.5s delay before reading pixels of the secondary CCD, increasing the maximum guiding speed from less than 2Hz to at least 5Hz (10Hz with small frame sizes).