### PR TITLE
Add udev rules for ccd rpi

### DIFF
--- a/indigo_optional_drivers/ccd_rpi/indigo_ccd_rpi.rules
+++ b/indigo_optional_drivers/ccd_rpi/indigo_ccd_rpi.rules
@@ -1,0 +1,9 @@
+KERNEL=="video[0-9]*",    GROUP="video",  MODE="0666"
+KERNEL=="media[0-9]*",    GROUP="video",  MODE="0666"
+KERNEL=="v4l-subdev*",    GROUP="video",  MODE="0666"
+
+# dma-buf providers
+SUBSYSTEM=="dma_heap",    GROUP="video",  MODE="0666"
+
+# DRM render node (sometimes used by libcamera pipelines)
+KERNEL=="renderD*",       GROUP="render", MODE="0666"


### PR DESCRIPTION
Problem: the default indigo service user can’t open the camera’s media nodes and can’t access a dma-buf provider. Add udev rules so that all users of indigo service can access media nodes.