### PR TITLE
Increase OBJECT_LENGTH from 41 to 43

### DIFF
--- a/indigo_libs/indigo_ccd_driver.c
+++ b/indigo_libs/indigo_ccd_driver.c
@@ -47,7 +47,7 @@
 #include <indigo/indigo_md5.h>
 #include <indigo/indigo_stretch.h>
 
-#define OBJECT_LENGTH 41
+#define OBJECT_LENGTH 43
 
 struct indigo_jpeg_compress_struct {
 	struct jpeg_compress_struct pub;


### PR DESCRIPTION
WebSocket over JSON implementation must support CJK languages (Chinese, Japanese, Korean), where a single character typically occupies 3-byte width in UTF-8 encoding, otherwise the connection will fail.