### PR TITLE
Add support for Sony Alpha A7RIV and ZV-E10

### DIFF
--- a/indigo_drivers/ccd_ptp/ptp_camera_model.h
+++ b/indigo_drivers/ccd_ptp/ptp_camera_model.h
@@ -168,7 +168,7 @@ static ptp_camera_model CAMERA[] = {
   { SONY_VID, 0x0e0c, "Sony Alpha A7RV", ptp_flag_lv, 9504, 6336, 3.76 },
   { SONY_VID, 0x0e78, "Sony Alpha A6700", ptp_flag_lv, 6192, 4128, 3.76 },
   { SONY_VID, 0x0d9f, "Sony Alpha A7RIV", ptp_flag_lv, 9504, 6336, 3.76 },
-  { SONY_VID, 0x0d97, "Sony ZV-E10 ", ptp_flag_lv, 6024, 4024, 3.9 },
+  { SONY_VID, 0x0d97, "Sony ZV-E10", ptp_flag_lv, 6024, 4024, 3.9 },
   { SONY_VID, 0xFFFF, "Sony Camera", ptp_flag_lv, 0, 0, 0 },
   { 0 },
 };


### PR DESCRIPTION
Tested with real cameras.
$ lsusb
Bus 006 Device 020: ID 054c:0d97 Sony Corp. ZV-E10

$ lsusb
Bus 006 Device 018: ID 054c:0d9f Sony Corp. ILCE-7RM4A

https://www.sony.com.hk/zh/electronics/interchangeable-lens-cameras/ilce-7rm4a