### PR TITLE
Validate device response data in indigo_mount_lx200

### DIFF
--- a/indigo_drivers/mount_lx200/indigo_mount_lx200.c
+++ b/indigo_drivers/mount_lx200/indigo_mount_lx200.c
@@ -363,6 +363,13 @@ static bool meade_open(indigo_device *device) {
 						}
 					}
 				}
+				// Confirm device response data is correct
+				if (PRIVATE_DATA->handle >= 0) {
+					if(!meade_command(device, ":GC#", response, sizeof(response), 0) || strlen(response) != 8 || response[2] != '/' || response[5] != '/') {
+						close(PRIVATE_DATA->handle);
+						PRIVATE_DATA->handle = -1;
+					}
+				}
 			}
 		}
 	} else {


### PR DESCRIPTION
Added validation for device response data to ensure correctness before proceeding.

Got wrong response data when the mount’s port might be incorrectly assigned to indigo_aux_wcv4ec instead of the correct serial/USB port.
```
19:47:38.722068 indigo_server: indigo_mount_lx200[meade_command:455]: Len:26, Command :GC# ->    %  Jz Z   
19:47:39.068635 indigo_server: indigo_mount_lx200[meade_command:455]: Len:25, Command :GL# ->  o38sJz Z   )
```

Stricter checks should be performed:
`19:49:09.259015 indigo_server: indigo_mount_lx200[meade_command:455]: Len:8, Command :GC# -> 10/24/25`