### PR TITLE
Update timer to use CLOCK_MONOTONIC for timekeeping

### DIFF
--- a/indigo_libs/indigo_timer.c
+++ b/indigo_libs/indigo_timer.c
@@ -47,7 +47,7 @@
 //}
 //#endif
 
-#define utc_time(ts) clock_gettime(CLOCK_REALTIME, ts)
+#define utc_time(ts) clock_gettime(CLOCK_MONOTONIC, ts)
 
 #define NANO	1000000000L
 
@@ -179,7 +179,11 @@ bool indigo_set_timer_with_data(indigo_device *device, double delay, indigo_time
 		INDIGO_TRACE(indigo_trace("timer #%d - allocating (%p)", t->timer_id, t));
 		pthread_mutex_init(&t->mutex, NULL);
 		pthread_mutex_init(&t->callback_mutex, NULL);
-		pthread_cond_init(&t->cond, NULL);
+		pthread_condattr_t condattr;
+    pthread_condattr_init(&condattr);
+    pthread_condattr_setclock(&condattr, CLOCK_MONOTONIC);
+    pthread_cond_init(&t->cond, &condattr);
+    pthread_condattr_destroy(&condattr);
 		t->canceled = false;
 		t->callback_running = false;
 		t->scheduled = true;


### PR DESCRIPTION
Change:​ Switched the clock source from CLOCK_REALTIMEto CLOCK_MONOTONICfor utc_timeand condition variables (via pthread_cond_init) to prevent issues caused by system time changes.

Bug Reproduction:
- Power on the host Pi and set its system time to TIME_1. 
- Connect the device and set a timer.
- Advance the host system time to TIME_2(where TIME_2 > TIME_1). 
- Set the host system time back to TIME_3(where TIME_3 < TIME_2). 

Result:​ The timer may hang indefinitely.