### PR TITLE
Rename INFO_PROPERTY_NAME to DEVICE_INFO

### DIFF
--- a/indigo_libs/indigo/indigo_names.h
+++ b/indigo_libs/indigo/indigo_names.h
@@ -25,7 +25,7 @@
 //----------------------------------------------------------------------
 /** INFO property name.
  */
-#define INFO_PROPERTY_NAME										"INFO"
+#define INFO_PROPERTY_NAME										"DEVICE_INFO"
 
 /** INFO.DEVICE_NAME property item name.
  */


### PR DESCRIPTION
The translation function in `/indigo_libs/indigo_filter.c` rewrites the `CCD_INFO` property (found in the Camera group). 

To accelerate the astrometry solver, follow this workflow:
- Enter the focal length of your imaging scope.
- Run a plate solve. The solver returns the image scale.
- Recompute the Effective Focal Length using the obtained scale.

But I can not found the `PIXEL_SIZE` in `CCD_INFO`. 
Above change will not affect the mappings in `/indigo_libs/indigo_version.c`.