### PR TITLE
Limit midtones range to prevent overexposure

### DIFF
--- a/indigo_libs/indigo_stretch.cpp
+++ b/indigo_libs/indigo_stretch.cpp
@@ -225,6 +225,12 @@ template <typename T> void indigo_compute_stretch_params(const T *buffer, int wi
 	} else {
 		*midtones = ((M - 1) * X) / ((2 * M - 1) * X - M);
 	}
+	// Limit the range of the midtones to prevent complete blackout when overexposure causes k1 to equal 0
+	if (*midtones > 0.99f) {
+		*midtones = 0.99f;
+	} else if (*midtones < 0.01f) {
+		*midtones = 0.01f;
+	}
 }
 
 


### PR DESCRIPTION
Added range limits for midtones to prevent overexposure.

Testing conducted with:
Cameras: ZWO ASI 462, Playerone Ceres 462M, Touptek G3CMOS08300KPA Exposure times: 0.0001s, 0.001s, 1s, and 5s
Format: RAW16  (Normal before add limits)
Note:​ When using RAW8, RGB24, or Y8 formats, an overexposed image will turn completely black after stretching.