### PR TITLE
Fix placeholder for temperature and update index

### DIFF
--- a/indigo_libs/indigo_ccd_driver.c
+++ b/indigo_libs/indigo_ccd_driver.c
@@ -2371,10 +2371,10 @@ void indigo_process_dslr_image(indigo_device *device, void *data, int data_size,
 		indigo_fits_keyword keywords[] = {
 			{ INDIGO_FITS_STRING, "BAYERPAT", .string = output_image.bayer_pattern, "Bayer color pattern" },
 			{ INDIGO_FITS_NUMBER, "ISOSPEED", .number = image_info.iso_speed, "ISO camera setting" },
-			{ 0 }, //Placeholder for trmerature
+			{ 0 }, //Placeholder for temperature
 			{ 0 }
 		};
-		int index = 1;
+		int index = 2;
 		if (image_info.temperature > -273.15f) {
 			keywords[index++] = (indigo_fits_keyword) { INDIGO_FITS_NUMBER, "CCD-TEMP", .number = image_info.temperature, "CCD temperature [celcius]"};
 		}


### PR DESCRIPTION
If the index is set to 1, the ISOSPEED parameter will be overwritten. Tested.