### PR TITLE
ccd_ptp: fix Canon RAM leaking

### DIFF
--- a/indigo_drivers/ccd_ptp/indigo_ptp_canon.c
+++ b/indigo_drivers/ccd_ptp/indigo_ptp_canon.c
@@ -1208,6 +1208,7 @@ static void ptp_canon_get_event(indigo_device *device) {
 								// Old camera (EOS 70D etc.)
 								if (!CANON_PRIVATE_DATA->use_ram) {
 									// If storage is available, ObjectAddedEx will be notified.
+									ptp_transaction_1_0(device, ptp_operation_canon_TransferComplete, handle);
 									break;
 								}
 							}


### PR DESCRIPTION
I noticed that when I take photos with the memory card inserted, the camera stops working after taking a few shots.

This was due to an insufficient implementation of memory card support.
