### PR TITLE
Handle overexposed images are rendered black

### DIFF
--- a/indigo_libs/indigo_stretch.cpp
+++ b/indigo_libs/indigo_stretch.cpp
@@ -216,6 +216,13 @@ template <typename T> void indigo_compute_stretch_params(const T *buffer, int wi
 		X = normalized_median - *shadows;
 		M = B;
 	}
+	// Ensure M has a minimum value to prevent midtones from becoming extreme
+	// When M approaches 0, the midtones formula produces values close to 1
+	// This causes k1 = (midtones - 1) ≈ 0, resulting in all-black output
+	const float M_MIN = 0.001f;
+	if (M < M_MIN) {
+		M = M_MIN;
+	}
 	if (X == 0) {
 		*midtones = 0.0f;
 	} else if (X == M) {


### PR DESCRIPTION
Added a minimum value check for M to prevent extreme midtones.

https://github.com/indigo-astronomy/indigo/issues/510 earthonlinegame:patch-28: PR #698