### PR TITLE
Add delay during exposure state in image capture after ABORT

### DIFF
--- a/indigo_drivers/agent_imager/indigo_agent_imager.c
+++ b/indigo_drivers/agent_imager/indigo_agent_imager.c
@@ -1050,6 +1050,8 @@ static void preview_1_process(indigo_device *device) {
 	int upload_mode = indigo_save_switch_state(device, CCD_UPLOAD_MODE_PROPERTY_NAME, CCD_UPLOAD_MODE_CLIENT_ITEM_NAME);
 	int image_format = indigo_save_switch_state(device, CCD_IMAGE_FORMAT_PROPERTY_NAME, CCD_IMAGE_FORMAT_RAW_ITEM_NAME);
 	capture_and_process_frame(device, &saturation_mask);
+	for (int i = 0; i < 5000 && DEVICE_PRIVATE_DATA->exposure_state == INDIGO_BUSY_STATE; i++)
+    indigo_usleep(1000);
 	indigo_restore_switch_state(device, CCD_UPLOAD_MODE_PROPERTY_NAME, upload_mode);
 	indigo_restore_switch_state(device, CCD_IMAGE_FORMAT_PROPERTY_NAME, image_format);
 	indigo_safe_free(saturation_mask);
@@ -1074,6 +1076,8 @@ static void preview_process(indigo_device *device) {
 	int image_format = indigo_save_switch_state(device, CCD_IMAGE_FORMAT_PROPERTY_NAME, CCD_IMAGE_FORMAT_RAW_ITEM_NAME);
 	while (capture_and_process_frame(device, &saturation_mask))
 		;
+	for (int i = 0; i < 5000 && DEVICE_PRIVATE_DATA->exposure_state == INDIGO_BUSY_STATE; i++)
+    indigo_usleep(1000);
 	indigo_restore_switch_state(device, CCD_UPLOAD_MODE_PROPERTY_NAME, upload_mode);
 	indigo_restore_switch_state(device, CCD_IMAGE_FORMAT_PROPERTY_NAME, image_format);
 	indigo_safe_free(saturation_mask);


### PR DESCRIPTION
Here is the log:
```text
282 19:10:51.325728 [561298] indigo_server: indigo_ccd_playerone[exposure_timer_callback:529]: POAStopExposure(0)
 283 19:10:51.325914 [561298] indigo_server: B <+ #### 'Imager Agent'.'CCD_EXPOSURE' NUMBER rw Ok 2.0 0  { // Start exposure
 284 19:10:51.325969 [561298] indigo_server: B <+   'EXPOSURE' = 0, target = 1 (1e-05, 7200, 1, '%g') // Start exposure
 285 19:10:51.325999 [561298] indigo_server: B <- }
 286 19:10:51.333948 [561312] indigo_server: B <+ #### 'Imager Agent'.'CCD_EXPOSURE' NUMBER rw Busy 2.0 0  { // Start exposure
 287 19:10:51.334089 [561312] indigo_server: B <+   'EXPOSURE' = 1, target = 1 (1e-05, 7200, 1, '%g') // Start exposure
 288 19:10:51.334125 [561312] indigo_server: B <- }
 289 19:10:51.334707 [561298] indigo_server: indigo_ccd_playerone[playerone_setup_exposure:259]: POAStopExposure(0)
 290 19:10:51.334779 [561298] indigo_server: indigo_ccd_playerone[playerone_setup_exposure:308]: POASetImageFormat(0, 0)
 291 19:10:51.338605 [561298] indigo_server: indigo_ccd_playerone[playerone_setup_exposure:318]: POASetConfig(0, POA_EXP, 1.000000)
 292 19:10:51.359044 [561298] indigo_server: indigo_ccd_playerone[exposure_timer_callback:456]: POAStartExposure(0, true)
 293 19:10:52.359391 [561298] indigo_server: B <+ #### 'Imager Agent'.'CCD_EXPOSURE' NUMBER rw Busy 2.0 0  { // Start exposure
 294 19:10:52.359567 [561298] indigo_server: B <+   'EXPOSURE' = 0, target = 1 (1e-05, 7200, 1, '%g') // Start exposure
 295 19:10:52.359655 [561298] indigo_server: B <- }
 296 19:10:52.556622 [561298] indigo_server: indigo_ccd_playerone[exposure_timer_callback:513]: POAGetImageData(0, ..., > 4262272, 2000)
 298 19:10:52.650995 [561298] indigo_server: RAW to preview conversion in 0.141771s
 299 19:10:52.657844 [561298] indigo_server: Client upload in 0.148704s
 300 19:10:52.808989 [561298] indigo_server: indigo_ccd_playerone[exposure_timer_callback:529]: POAStopExposure(0)
 301 19:10:52.809343 [561298] indigo_server: B <+ #### 'Imager Agent'.'CCD_EXPOSURE' NUMBER rw Ok 2.0 0  { // Start exposure
 302 19:10:52.809449 [561298] indigo_server: B <+   'EXPOSURE' = 0, target = 1 (1e-05, 7200, 1, '%g') // Start exposure
 303 19:10:52.809496 [561298] indigo_server: B <- }
 304 19:10:52.815072 [561312] indigo_server: B <+ #### 'Imager Agent'.'CCD_EXPOSURE' NUMBER rw Busy 2.0 0  { // Start exposure
 305 19:10:52.815240 [561312] indigo_server: B <+   'EXPOSURE' = 1, target = 1 (1e-05, 7200, 1, '%g') // Start exposure
 306 19:10:52.815286 [561312] indigo_server: B <- }
 307 19:10:52.816355 [561298] indigo_server: indigo_ccd_playerone[playerone_setup_exposure:259]: POAStopExposure(0)
 308 19:10:52.816516 [561298] indigo_server: indigo_ccd_playerone[playerone_setup_exposure:308]: POASetImageFormat(0, 0)
 309 19:10:52.820083 [561298] indigo_server: indigo_ccd_playerone[playerone_setup_exposure:318]: POASetConfig(0, POA_EXP, 1.000000)
 310 19:10:52.840479 [561298] indigo_server: indigo_ccd_playerone[exposure_timer_callback:456]: POAStartExposure(0, true)
 311 19:10:53.743579 [671448] indigo_server: 29 -> {"newSwitchVector":{"name":"AGENT_ABORT_PROCESS","device":"Imager Agent","items":[{"name":"ABORT","value":true}]}}
 312 19:10:53.952654 [671448] indigo_server: JSON Parser: message processed in 208882 us
 313 19:10:53.953757 [561312] indigo_server: upload_mode restore to:2 in preview_process
 314 19:10:53.953934 [561298] indigo_server: B <+ #### 'Imager Agent'.'CCD_EXPOSURE' NUMBER rw Busy 2.0 0  { // Start exposure
 315 19:10:53.954021 [561298] indigo_server: B <+   'EXPOSURE' = 0, target = 1 (1e-05, 7200, 1, '%g') // Start exposure
 316 19:10:53.954061 [561298] indigo_server: B <- }
 317 19:10:54.046587 [561298] indigo_server: indigo_ccd_playerone[exposure_timer_callback:513]: POAGetImageData(0, ..., > 4262272, 2000)
 319 19:10:54.152581 [561298] indigo_server: RAW to preview conversion in 0.146538s
 320 19:10:54.473807 [561298] indigo_server: RAW to FITS conversion in 0.00012s
 321 19:10:54.474963 [561298] indigo_server: open(/mnt/disk/Test_Light_2026-02-06_19-10-54_001.fits) -> 0
 322 19:10:54.475380 [561298] indigo_server: write 2134080 bytes to 24
 323 19:10:54.482718 [561298] indigo_server: file /mnt/disk/Test_Light_2026-02-06_19-10-54_001.fits saved, size: 2134080 bytes (expected: 2134080)
```