### PR TITLE
mount_nexstar: fix about version number comparison

### DIFF
--- a/indigo_drivers/mount_nexstar/externals/libnexstar/src/nexstar.c
+++ b/indigo_drivers/mount_nexstar/externals/libnexstar/src/nexstar.c
@@ -323,8 +323,7 @@ int _tc_sync_rade(int dev, double ra, double de, char precise) {
 	char reply;
 
 	if (VENDOR(VNDR_SKYWATCHER)) {
-		REQUIRE_RELEASE(3);
-		REQUIRE_REVISION(37);
+		REQUIRE_VER(VER_3_37);
 	} else {
 		REQUIRE_VER(VER_4_10);
 	}
@@ -363,8 +362,7 @@ int tc_get_side_of_pier(int dev) {
 	char reply[2];
 
 	if (VENDOR(VNDR_SKYWATCHER)) {
-		REQUIRE_RELEASE(3);
-		REQUIRE_REVISION(37);
+		REQUIRE_VER(VER_3_37);
 	} else {
 		REQUIRE_VER(VER_4_15);
 	}
@@ -576,8 +574,7 @@ int tc_slew_fixed(int dev, char axis, char direction, char rate) {
 	char axis_id, cmd_id, res;
 
 	if (VENDOR(VNDR_SKYWATCHER)) {
-		REQUIRE_RELEASE(3);
-		REQUIRE_REVISION(1);
+		REQUIRE_VER(VER_3_1);
 	} else {
 		REQUIRE_VER(VER_1_6);
 	}
@@ -597,8 +594,7 @@ int tc_slew_variable(int dev, char axis, char direction, float rate) {
 	char axis_id, cmd_id, res;
 
 	if (VENDOR(VNDR_SKYWATCHER)) {
-		REQUIRE_RELEASE(3);
-		REQUIRE_REVISION(1);
+		REQUIRE_VER(VER_3_1);
 	} else {
 		REQUIRE_VER(VER_1_6);
 	}

--- a/indigo_drivers/mount_nexstar/externals/libnexstar/src/nexstar.h
+++ b/indigo_drivers/mount_nexstar/externals/libnexstar/src/nexstar.h
@@ -81,6 +81,7 @@
 #define VER_2_2  0x20200
 #define VER_2_3  0x20300
 #define VER_3_1  0x30100
+#define VER_3_37 0x32500
 #define VER_4_10 0x40A00
 #define VER_4_15 0x40F00
 #define VER_3_37_8 0x32508


### PR DESCRIPTION
I found an issue where the slewing function does not work with SkyWatcher's SynScan controller version v6.00.07.

```
indigo_mount_nexstar[mount_handle_motion_ns:700]: tc_slew_fixed(7) = -5 (No such file or directory)
```

This issue appears to be failing due to revision number comparison.
https://github.com/indigo-astronomy/indigo/blob/e82850a315d5db5a9a0c988d3d7ec3baa2233b15/indigo_drivers/mount_nexstar/externals/libnexstar/src/nexstar.c#L580
