### PR TITLE
Increase maximum cover position

### DIFF
--- a/indigo_drivers/aux_wcv4ec/indigo_aux_wcv4ec.c
+++ b/indigo_drivers/aux_wcv4ec/indigo_aux_wcv4ec.c
@@ -300,8 +300,8 @@ static indigo_result aux_attach(indigo_device *device) {
 		AUX_SET_OPEN_CLOSE_PROPERTY = indigo_init_number_property(NULL, device->name, "X_COVER_SET_OPEN_CLOSE", AUX_ADVANCED_GROUP, "Set cover open/close position", INDIGO_OK_STATE, INDIGO_RW_PERM, 2);
 		if (AUX_SET_OPEN_CLOSE_PROPERTY == NULL)
 			return INDIGO_FAILED;
-		indigo_init_number_item(AUX_SET_OPEN_CLOSE_OPEN_ITEM, AUX_COVER_OPEN_ITEM_NAME, "Set Open [°]", 0, 290, 1, 110);
-		indigo_init_number_item(AUX_SET_OPEN_CLOSE_CLOSE_ITEM, AUX_COVER_CLOSE_ITEM_NAME, "Set Close [°]", 0, 290, 1, 22);
+		indigo_init_number_item(AUX_SET_OPEN_CLOSE_OPEN_ITEM, AUX_COVER_OPEN_ITEM_NAME, "Set Open [°]", 0, 295, 1, 110);
+		indigo_init_number_item(AUX_SET_OPEN_CLOSE_CLOSE_ITEM, AUX_COVER_CLOSE_ITEM_NAME, "Set Close [°]", 0, 295, 1, 22);
 		// -------------------------------------------------------------------------------- X_HEATER
 		AUX_HEATER_PROPERTY = indigo_init_switch_property(NULL, device->name, "X_HEATER", AUX_MAIN_GROUP, "Heater", INDIGO_OK_STATE, INDIGO_RW_PERM, INDIGO_ONE_OF_MANY_RULE, 4);
 		if (AUX_HEATER_PROPERTY == NULL)


### PR DESCRIPTION
When my WandererCover V4-EC opens at the current maximum position of 290º, it hovers ever so slightly over the telescope tube when it is positioned above it. I put a small furniture pad on the tube to at least have it touch it . But I found that if the telescope is oriented such that the cover is near its side, this distance increases to over a cm, potentially having the cover flopping slightly in the wind.

This change increases the maximum limit to 295º. In my case 291º will cause it to touch the tube in every telescope orientation.