### PR TITLE
Add session night file name template placeholder

### DIFF
--- a/indigo_docs/CCD_DRIVER_SAVED_IMAGES.md
+++ b/indigo_docs/CCD_DRIVER_SAVED_IMAGES.md
@@ -51,6 +51,8 @@ INDIGO file name templates support a number of placeholders starting with "%" ch
 
 * **%D**, **%-D** or **%.D** - expands to the date in formats respectively: YYYYMMDD, YYYY-MM-DD or YYYY.MM.DD
 
+* **%N**, **%-N** or **%.N** - expands to the date of the imaging session night in formats respectively: YYYYMMDD, YYYY-MM-DD or YYYY.MM.DD
+
 * **%H**, **%-H** or **%.H** - expands to the local time in formats respectively: HHMMSS, HH-MM-SS or HH.MM.SS
 
 * **%C** - expands to the filter name: "R", "G", "B", "Ha", "OIII" etc. This placeholder reads *FILTER* keyword set in the **CCD_FITS_HEADERS** property, if not set it will expand to "nofilter". INDIGO Imager Agent sets this keyword if filer wheel is selected.

--- a/indigo_libs/indigo_ccd_driver.c
+++ b/indigo_libs/indigo_ccd_driver.c
@@ -1440,13 +1440,19 @@ static bool create_file_name(indigo_device *device, void *blob_value, long blob_
 			strncpy(tmp, format, fs - format);
 			strcat(tmp, fs + 2);
 			strcpy(format, tmp);
-		} else if ((fs[1] == 'D' || fs[1] == 'H') || ((fs[1] == '.' || fs[1] == '-') && (fs[2] == 'D' || fs[2] == 'H'))) { // %D, %.D, %-D - date, %H, %.H, %-H - time
+		} else if ((fs[1] == 'D' || fs[1] == 'N' || fs[1] == 'H') || ((fs[1] == '.' || fs[1] == '-') && (fs[2] == 'D' || fs[2] == 'N' || fs[2] == 'H'))) { // %D, %.D, %-D - date, %N, %.N, %-N - session night, %H, %.H, %-H - time
 			struct tm * time_info;
 			char buffer[15];
 			time_info = localtime(&current_time);
 			if (fs[1] == 'H') {
 				strftime(buffer, 15, "%H%M%S", time_info);
 			} else if (fs[1] == 'D') {
+				strftime(buffer, 15, "%Y%m%d", time_info);
+			} else if (fs[1] == 'N') {
+				if (time_info->tm_hour < 12) {
+					time_info->tm_hour -= 12;
+					mktime(time_info);
+				}
 				strftime(buffer, 15, "%Y%m%d", time_info);
 			} else if (fs[2] == 'H') {
 				if (fs[1] == '.')
@@ -1458,10 +1464,19 @@ static bool create_file_name(indigo_device *device, void *blob_value, long blob_
 					strftime(buffer, 15, "%Y.%m.%d", time_info);
 				else if (fs[1] == '-')
 					strftime(buffer, 15, "%Y-%m-%d", time_info);
+			} else if (fs[2] == 'N') {
+				if (time_info->tm_hour < 12) {
+					time_info->tm_hour -= 12;
+					mktime(time_info);
+				}
+				if (fs[1] == '.')
+					strftime(buffer, 15, "%Y.%m.%d", time_info);
+				else if (fs[1] == '-')
+					strftime(buffer, 15, "%Y-%m-%d", time_info);
 			}
 			strncpy(tmp, format, fs - format);
 			strcat(tmp, buffer);
-			if (fs[1] == 'D' || fs[1] == 'H')
+			if (fs[1] == 'D' || fs[1] == 'N' || fs[1] == 'H')
 				strcat(tmp, fs + 2);
 			else
 				strcat(tmp, fs + 3);

--- a/indigo_libs/indigo_ccd_driver.c
+++ b/indigo_libs/indigo_ccd_driver.c
@@ -1449,10 +1449,8 @@ static bool create_file_name(indigo_device *device, void *blob_value, long blob_
 			} else if (fs[1] == 'D') {
 				strftime(buffer, 15, "%Y%m%d", time_info);
 			} else if (fs[1] == 'N') {
-				if (time_info->tm_hour < 12) {
-					time_info->tm_hour -= 12;
-					mktime(time_info);
-				}
+				time_info->tm_hour -= 12;
+				mktime(time_info);
 				strftime(buffer, 15, "%Y%m%d", time_info);
 			} else if (fs[2] == 'H') {
 				if (fs[1] == '.')
@@ -1465,10 +1463,8 @@ static bool create_file_name(indigo_device *device, void *blob_value, long blob_
 				else if (fs[1] == '-')
 					strftime(buffer, 15, "%Y-%m-%d", time_info);
 			} else if (fs[2] == 'N') {
-				if (time_info->tm_hour < 12) {
-					time_info->tm_hour -= 12;
-					mktime(time_info);
-				}
+				time_info->tm_hour -= 12;
+				mktime(time_info);
 				if (fs[1] == '.')
 					strftime(buffer, 15, "%Y.%m.%d", time_info);
 				else if (fs[1] == '-')


### PR DESCRIPTION
Add file name template placeholder %N, %-N and %.N for the imaging session evening/night. This ensures that the date doesn't change in my file names of a session for images taken after midnight.