### PR TITLE
tools: fix indigo_tools uninstall list

### DIFF
--- a/indigo_tools/Makefile
+++ b/indigo_tools/Makefile
@@ -38,7 +38,7 @@ install: all
 	cp ./indigo_log_analyzer.pl $(INSTALL_BIN)/indigo_log_analyzer
 
 uninstall:
-	rm -f $(INSTALL_BIN)/indigo_prop_tool $(INSTALL_BIN)/indigo_raw_to_fits $(BUILD_BIN)/indigo_raw_crop $(INSTALL_BIN)/indigo_log_analyzer
+	rm -f $(INSTALL_BIN)/indigo_prop_tool $(INSTALL_BIN)/indigo_raw_to_fits $(INSTALL_BIN)/indigo_raw_crop $(INSTALL_BIN)/indigo_log_analyzer $(INSTALL_BIN)/indigo_list_usbserial
 
 status:
 	@printf "\nindigo_tools -------------------------\n\n"


### PR DESCRIPTION
Update indigo_tools/Makefile so "make uninstall" removes all installed tools.

Add missing uninstall targets for indigo_raw_crop and indigo_list_usbserial and remove the incorrect $(BUILD_BIN)/indigo_raw_crop path.