### PR TITLE
indigo_ccd_qhy2: Increase number of wheel slots to 8 (#751)

### DIFF
--- a/indigo_drivers/ccd_qhy/indigo_ccd_qhy.cpp
+++ b/indigo_drivers/ccd_qhy/indigo_ccd_qhy.cpp
@@ -89,7 +89,7 @@
 #define MAX_CCD_TEMP               40.0
 #define TEMP_THRESHOLD             0.3
 
-#define FW_COUNT									 7
+#define FW_COUNT									 8
 
 #define PRIVATE_DATA               ((qhy_private_data *)device->private_data)
 
@@ -1699,7 +1699,7 @@ static void process_plug_event() {
 		device->master_device = master_device;
 		sprintf(device->name, "%s Guider #%s", dev_name, dev_usbpath);
 		INDIGO_DEVICE_ATTACH_LOG(DRIVER_NAME, device->name);
-		private_data->fw_count = FW_COUNT; /* No way to get it from SDK but all QHY FWs have 5 or 7 slots */
+		private_data->fw_count = FW_COUNT; /* No way to get it from SDK but all QHY FWs have 5 or 7 or 8 slots */
 		device->private_data = private_data;
 		indigo_attach_device(device);
 		devices[slot]=device;


### PR DESCRIPTION
The QHY miniCAM8 (released 2024) has 8 filter slots, so this change increases the hard-coded number of wheel slots from 7 to 8.

Unfortunately, we still cannot use `CONTROL_CFWSLOTSNUM` to get the number of slots from the SDK, as querying it returns `QHYCCD_ERROR` even for this recent camera.

Tested with: QHY miniCAM8 (Linux arm64, QHY SDK 25.09.29)